### PR TITLE
Fix missing quiz/nav.html.twig and add template reference integrity test

### DIFF
--- a/templates/quiz/nav.html.twig
+++ b/templates/quiz/nav.html.twig
@@ -1,0 +1,16 @@
+{% if is_granted('IS_AUTHENTICATED') or app.current_route() == 'tvdt_quiz_select_season' %}
+    <div class="quiz-topbar">
+        {% if is_granted('IS_AUTHENTICATED') %}
+            <a href="{{ path('tvdt_backoffice_index') }}" class="btn btn-outline-secondary btn-sm">
+                {{ 'Backoffice'|trans }}
+            </a>
+            <a href="{{ path('tvdt_login_logout') }}" class="btn btn-outline-secondary btn-sm">
+                {{ 'Logout'|trans }}
+            </a>
+        {% else %}
+            <a href="{{ path('tvdt_backoffice_index') }}" class="btn btn-outline-secondary btn-sm">
+                {{ 'Manage Quiz'|trans }}
+            </a>
+        {% endif %}
+    </div>
+{% endif %}

--- a/tests/Twig/TemplateReferencesTest.php
+++ b/tests/Twig/TemplateReferencesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Twig;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function Safe\file_get_contents;
+use function Safe\preg_match_all;
+
+final class TemplateReferencesTest extends TestCase
+{
+    private static string $templatesDir;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$templatesDir = \dirname(__DIR__, 2).'/templates';
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function templateReferenceProvider(): iterable
+    {
+        $templatesDir = \dirname(__DIR__, 2).'/templates';
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($templatesDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            Assert::assertInstanceOf(\SplFileInfo::class, $file);
+            if ('twig' !== $file->getExtension()) {
+                continue;
+            }
+
+            $content = file_get_contents($file->getPathname());
+            $sourceFile = str_replace($templatesDir.'/', '', $file->getPathname());
+
+            // Match extends, include(), and embed tags — capture the quoted template name
+            preg_match_all(
+                '/(?:extends|include|embed)\s*\(?[\'"]([^\'"]+)[\'"]\)?/',
+                $content,
+                $matches,
+            );
+
+            foreach ($matches[1] as $referencedTemplate) {
+                yield \sprintf('%s → %s', $sourceFile, $referencedTemplate) => [$sourceFile, $referencedTemplate];
+            }
+        }
+    }
+
+    #[DataProvider('templateReferenceProvider')]
+    public function testReferencedTemplateExists(string $sourceFile, string $referencedTemplate): void
+    {
+        $absolutePath = self::$templatesDir.'/'.$referencedTemplate;
+
+        $this->assertFileExists(
+            $absolutePath,
+            \sprintf("Template '%s' references '%s' which does not exist at '%s'.", $sourceFile, $referencedTemplate, $absolutePath),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the previously uncommitted `templates/quiz/nav.html.twig` partial that broke `main` (it was included by `quiz/base.html.twig` but never committed)
- Introduces `tests/Twig/TemplateReferencesTest` — a data-provider test that crawls all Twig templates, extracts every `extends`/`include`/`embed` reference, and asserts the target file exists on disk

## Test plan

- [ ] `just test tests/Twig/TemplateReferencesTest.php` passes (20 assertions, one per template reference)
- [ ] Deleting any referenced template causes the test to fail with a clear message naming the broken reference
- [ ] Full test suite (`just test`) stays green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a top navigation bar for the quiz area that appears in the relevant quiz pages.
  * Show different actions based on sign-in status, including Backoffice and Logout for signed-in users, and a Manage Quiz link for others.

* **Tests**
  * Added automated checks to ensure referenced Twig templates exist, helping catch broken template links earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->