### PR TITLE
ci: optimise build pipeline — shared dev image build and skip tests on tag push

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build
+    if: "!startsWith(github.ref, 'refs/tags/')"
     permissions:
       contents: read
     steps:
@@ -100,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build
+    if: "!startsWith(github.ref, 'refs/tags/')"
     permissions:
       checks: write
       pull-requests: write
@@ -137,6 +139,27 @@ jobs:
       - name: Doctrine Schema Validator
         run: docker compose exec -T php bin/console -e test doctrine:schema:validate
 
+  verify-prior-run:
+    name: Verify Prior CI Run
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      actions: read
+    steps:
+      - name: Check for successful CI run on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&status=success&per_page=5" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length")
+          if [[ "$count" -eq 0 ]]; then
+            echo "::error::No prior successful CI run found for ${{ github.sha }}. Only tag commits that have passed CI on main."
+            exit 1
+          fi
+          echo "Found $count prior successful CI run(s) for this commit."
+
   build-deploy:
     name: Build and Deploy
     permissions:
@@ -145,10 +168,12 @@ jobs:
     environment:
       name: ${{ startsWith(github.ref, 'refs/tags/') && 'production' || 'acceptance' }}
       url: ${{ vars.URL }}
-    needs: [quality, tests]
+    needs: [quality, tests, verify-prior-run]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: (github.ref == 'refs/heads/main' && false) || startsWith(github.ref, 'refs/tags/')
+    if: >-
+      always() && !cancelled() && !failure() &&
+      ((github.ref == 'refs/heads/main' && false) || startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build Docker images
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v7
         with:
           pull: true
           files: |
@@ -52,11 +52,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Load Docker images
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v7
         with:
           load: true
           files: |
@@ -108,11 +108,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Load Docker images
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v7
         with:
           load: true
           files: |
@@ -132,7 +132,7 @@ jobs:
         run: docker compose exec -T php vendor/bin/phpunit --log-junit var/phpunit/junit.xml
       - name: Publish PHPUnit test results
         if: always()
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         with:
           report_paths: var/phpunit/junit.xml
           check_name: PHPUnit
@@ -176,11 +176,11 @@ jobs:
       ((github.ref == 'refs/heads/main' && false) || startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -208,7 +208,7 @@ jobs:
           fi
 
       - name: Build and Push Docker images
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v7
         with:
           pull: true
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ permissions:
   contents: read
 
 jobs:
-  quality:
-    name: Code Quality
+  build:
+    name: Build Dev Image
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -34,14 +34,35 @@ jobs:
         uses: docker/bake-action@v5
         with:
           pull: true
+          files: |
+            compose.yaml
+            compose.override.yaml
+          set: |
+            *.cache-from=type=gha,scope=${{github.ref}}-devbuild
+            *.cache-from=type=gha,scope=refs/heads/main-devbuild
+            *.cache-to=type=gha,scope=${{github.ref}}-devbuild,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }}
+
+  quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Load Docker images
+        uses: docker/bake-action@v5
+        with:
           load: true
           files: |
             compose.yaml
             compose.override.yaml
           set: |
-            *.cache-from=type=gha,scope=${{github.ref}}-quality
-            *.cache-from=type=gha,scope=refs/heads/main
-            *.cache-to=type=gha,scope=${{github.ref}}-quality,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }}
+            *.cache-from=type=gha,scope=${{github.ref}}-devbuild
       - name: Start services
         run: docker compose up php database --wait --no-build
       - name: Warm up dev cache
@@ -78,6 +99,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: build
     permissions:
       checks: write
       pull-requests: write
@@ -87,18 +109,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build Docker images
+      - name: Load Docker images
         uses: docker/bake-action@v5
         with:
-          pull: true
           load: true
           files: |
             compose.yaml
             compose.override.yaml
           set: |
-            *.cache-from=type=gha,scope=${{github.ref}}-tests
-            *.cache-from=type=gha,scope=refs/heads/main
-            *.cache-to=type=gha,scope=${{github.ref}}-tests,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }}
+            *.cache-from=type=gha,scope=${{github.ref}}-devbuild
       - name: Start services
         run: docker compose up php database --wait --no-build
       - name: Create test database

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Build Docker images
-        uses: docker/bake-action@v7
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7
         with:
           pull: true
           files: |
@@ -52,11 +52,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Load Docker images
-        uses: docker/bake-action@v7
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7
         with:
           load: true
           files: |
@@ -108,11 +108,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Load Docker images
-        uses: docker/bake-action@v7
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7
         with:
           load: true
           files: |
@@ -132,7 +132,7 @@ jobs:
         run: docker compose exec -T php vendor/bin/phpunit --log-junit var/phpunit/junit.xml
       - name: Publish PHPUnit test results
         if: always()
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         with:
           report_paths: var/phpunit/junit.xml
           check_name: PHPUnit
@@ -176,11 +176,11 @@ jobs:
       ((github.ref == 'refs/heads/main' && false) || startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -208,7 +208,7 @@ jobs:
           fi
 
       - name: Build and Push Docker images
-        uses: docker/bake-action@v7
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7
         with:
           pull: true
           push: true
@@ -222,7 +222,7 @@ jobs:
             *.tags=${{ steps.meta.outputs.full_name }}
 
       - name: Create Sentry release
-        uses: getsentry/action-release@v3
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
       - name: Set up Docker Buildx
@@ -53,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Load Docker images
@@ -109,6 +113,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Load Docker images
@@ -177,6 +183,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
## Summary

- Extract Docker image build into a dedicated `build` job so `quality` and `tests` no longer each build the image independently — both load from a shared GHA cache scope (`devbuild`).
- Skip `quality` and `tests` on tag pushes, since tags are cut from commits that already passed CI on main.
- Add a `verify-prior-run` job (tag pushes only) that queries the GitHub API for a prior successful CI run on the same SHA, failing fast if none is found — prevents deploying untested tags.
- Update `build-deploy` to use `always() && !cancelled() && !failure()` so it correctly handles the mix of skipped and successful needed jobs.

## Test plan

- [ ] PR/branch push: `build` → `quality` + `tests` run in parallel, `build-deploy` skipped
- [ ] Tag on a commit that passed CI on main: `build` → `verify-prior-run` passes, `quality`/`tests` skipped, `build-deploy` runs
- [ ] Tag on an untested commit: `verify-prior-run` fails, `build-deploy` blocked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by reusing a shared build step for later checks and tests.
  * Added a safeguard to prevent releases unless the same commit has already passed a prior successful run on the main branch.

* **Chores**
  * Updated pipeline conditions so validation jobs only run where relevant, and deployments wait for all required checks to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->