### PR TITLE
fix: align SENTRY_RELEASE with Sentry action release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,4 +244,4 @@ jobs:
         env:
           PORTAINER_WEBHOOK: ${{secrets.PORTAINER_WEBHOOK}}
         run: |
-          curl -v -X POST "${PORTAINER_WEBHOOK}?IMAGE_TAG=${{steps.meta.outputs.tag}}" --fail-with-body
+          curl -v -X POST "${PORTAINER_WEBHOOK}?IMAGE_TAG=${{steps.meta.outputs.tag}}&SENTRY_RELEASE=${{steps.meta.outputs.sentry_version}}" --fail-with-body

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -10,7 +10,7 @@ services:
       MAILER_DSN: ${MAILER_DSN}
       MAILER_SENDER: ${MAILER_SENDER}
       SENTRY_DSN: ${SENTRY_DSN}
-      SENTRY_RELEASE: ${IMAGE_TAG}
+      SENTRY_RELEASE: ${SENTRY_RELEASE}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT}
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
## Summary

- The Sentry action creates releases using the `v`-stripped version (e.g. `0.1.1`), but `compose.prod.yaml` was setting `SENTRY_RELEASE` to `IMAGE_TAG` (e.g. `v0.1.1`)
- This caused Sentry to auto-create a second release from incoming events, labelling it `(non-semver)` instead of linking events to the properly created release
- Fix: pass `SENTRY_RELEASE` as a separate query param through the Portainer webhook (using the already-computed `sentry_version` output) and reference it in `compose.prod.yaml`

## Test plan

- [ ] Tag a new release and verify Sentry shows the release without a `(non-semver)` label
- [ ] Confirm events in Sentry are associated with the correct release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment settings to pass the correct release identifier through to production.
  * Improved release tracking so deployed builds can be matched more accurately with error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->