### PR TITLE
fix(ci): prevent script injection in Portainer deployment step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,5 +243,7 @@ jobs:
         shell: bash
         env:
           PORTAINER_WEBHOOK: ${{secrets.PORTAINER_WEBHOOK}}
+          IMAGE_TAG: ${{steps.meta.outputs.tag}}
+          SENTRY_RELEASE: ${{steps.meta.outputs.sentry_version}}
         run: |
-          curl -v -X POST "${PORTAINER_WEBHOOK}?IMAGE_TAG=${{steps.meta.outputs.tag}}&SENTRY_RELEASE=${{steps.meta.outputs.sentry_version}}" --fail-with-body
+          curl -v -X POST "${PORTAINER_WEBHOOK}?IMAGE_TAG=${IMAGE_TAG}&SENTRY_RELEASE=${SENTRY_RELEASE}" --fail-with-body


### PR DESCRIPTION
## Summary

- The `Trigger Portainer Deployment` step was interpolating `${{steps.meta.outputs.tag}}` and `${{steps.meta.outputs.sentry_version}}` directly into the shell `run` string via GitHub Actions template expansion.
- A crafted tag name or Sentry version value could break out of the URL argument and inject arbitrary shell commands.
- Fix: move both values into `env:` and reference them as `${IMAGE_TAG}` / `${SENTRY_RELEASE}` in the `curl` invocation. No behaviour change.

## Test plan

- [ ] Confirm the diff touches only the `Trigger Portainer Deployment` step.
- [ ] Verify CI passes on this branch (the step is only executed on tag pushes, so static linting and the quality/test jobs are the relevant checks here).