### PR TITLE
ci: improve tag pipeline — skip dev build, poll for in-progress runs, better error output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     name: Build Dev Image
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: "!startsWith(github.ref, 'refs/tags/')"
     permissions:
       contents: read
     steps:
@@ -97,8 +98,20 @@ jobs:
       - name: Assert all checks passed
         if: always()
         run: |
-          outcomes="${{ steps.twig_lint.outcome }} ${{ steps.cs.outcome }} ${{ steps.twig_cs.outcome }} ${{ steps.phpstan.outcome }} ${{ steps.rector.outcome }}"
-          if echo "$outcomes" | grep -q "failure"; then exit 1; fi
+          failed=0
+          check() {
+            local name="$1" outcome="$2"
+            if [[ "$outcome" == "failure" ]]; then
+              echo "::error::$name failed"
+              failed=1
+            fi
+          }
+          check "Twig Lint"        "${{ steps.twig_lint.outcome }}"
+          check "Coding Style"     "${{ steps.cs.outcome }}"
+          check "Twig Coding Style" "${{ steps.twig_cs.outcome }}"
+          check "PHPStan"          "${{ steps.phpstan.outcome }}"
+          check "Rector"           "${{ steps.rector.outcome }}"
+          exit $failed
 
   tests:
     name: Tests
@@ -148,23 +161,44 @@ jobs:
   verify-prior-run:
     name: Verify Prior CI Run
     runs-on: ubuntu-latest
-    needs: build
+    timeout-minutes: 20
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       actions: read
     steps:
-      - name: Check for successful CI run on this commit
+      - name: Wait for and verify successful CI run on this commit
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          count=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&status=success&per_page=5" \
-            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length")
-          if [[ "$count" -eq 0 ]]; then
-            echo "::error::No prior successful CI run found for ${{ github.sha }}. Only tag commits that have passed CI on main."
-            exit 1
-          fi
-          echo "Found $count prior successful CI run(s) for this commit."
+          max_attempts=30
+          attempt=0
+          while [[ $attempt -lt $max_attempts ]]; do
+            attempt=$((attempt + 1))
+
+            success_count=$(gh api \
+              "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&status=success&per_page=5" \
+              --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length")
+
+            if [[ "$success_count" -gt 0 ]]; then
+              echo "Found $success_count prior successful CI run(s) for ${{ github.sha }}."
+              exit 0
+            fi
+
+            in_progress_count=$(gh api \
+              "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&per_page=10" \
+              --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }}) | select(.status == \"in_progress\" or .status == \"queued\" or .status == \"waiting\" or .status == \"requested\" or .status == \"pending\")] | length")
+
+            if [[ "$in_progress_count" -gt 0 ]]; then
+              echo "CI still in progress (attempt $attempt/$max_attempts), waiting 30s..."
+              sleep 30
+            else
+              echo "::error::No prior successful CI run found for ${{ github.sha }}. Only tag commits that have passed CI on main."
+              exit 1
+            fi
+          done
+
+          echo "::error::Timed out waiting for CI run to complete for ${{ github.sha }}."
+          exit 1
 
   build-deploy:
     name: Build and Deploy


### PR DESCRIPTION
## Summary

- **Skip dev image build on tags** — the `build` job had no `if` guard, so it ran on every tag push even though `quality` and `tests` are skipped on tags. Added `if: "!startsWith(github.ref, 'refs/tags/')"` to skip it.
- **Remove unnecessary `needs: build` from `verify-prior-run`** — that job never used the dev image; the dependency was only forcing the wasted build to complete first.
- **Poll for in-progress CI runs** — `verify-prior-run` now retries every 30 seconds (up to 15 min) when the main-branch CI run is still in progress, so tagging immediately after pushing to main no longer fails instantly. Added `timeout-minutes: 20` as a hard ceiling.
- **Named error annotations in quality gate** — replaced the opaque yes/no outcomes string with per-step `::error::` annotations (e.g. `::error::PHPStan failed`) so GitHub highlights exactly which check failed.

## Test plan

- [ ] Push a tag — confirm `build` job is skipped, `verify-prior-run` runs independently
- [ ] Push a tag immediately after a commit to main — confirm `verify-prior-run` waits for the main CI run to finish
- [ ] Introduce a PHPStan violation — confirm the annotation says `::error::PHPStan failed` rather than a generic failure