### PR TITLE
feat: Sentry User Feedback in backoffice (#178)

### DIFF
--- a/assets/backoffice.js
+++ b/assets/backoffice.js
@@ -8,20 +8,29 @@ import * as Sentry from '@sentry/browser';
 const dsn = document.querySelector('meta[name="sentry-dsn"]')?.content ?? '';
 const userEmail = document.querySelector('meta[name="user-email"]')?.content ?? '';
 
-Sentry.init({
-    dsn: dsn || undefined,
-    // When no DSN is set (local dev), forward events to Spotlight instead
-    spotlight: !dsn,
-    integrations: [
-        Sentry.feedbackIntegration({
-            colorScheme: 'system',
-            showName: true,
-            showEmail: true,
-            isNameRequired: false,
-            isEmailRequired: false,
-        }),
-    ],
+// When no real DSN is configured, route to the local Spotlight sidecar so
+// nothing reaches Sentry. A syntactically valid DSN is still required for the
+// SDK to initialise; the tunnel option redirects all transport to Spotlight.
+const useSpotlight = !dsn;
+const effectiveDsn = dsn || 'https://0@o0.ingest.sentry.io/0';
+
+const feedbackIntegration = Sentry.feedbackIntegration({
+    colorScheme: 'system',
+    showName: true,
+    showEmail: true,
+    isNameRequired: false,
+    isEmailRequired: false,
+    autoInject: false,
 });
+
+Sentry.init({
+    dsn: effectiveDsn,
+    tunnel: useSpotlight ? 'http://localhost:8969/stream' : undefined,
+    integrations: [feedbackIntegration],
+});
+
+// autoInject is unreliable in Sentry v10 due to the setupOnce guard; mount manually.
+feedbackIntegration.createWidget();
 
 if (userEmail) {
     Sentry.setUser({ email: userEmail });

--- a/assets/backoffice.js
+++ b/assets/backoffice.js
@@ -3,3 +3,26 @@ import 'bootstrap-icons/font/bootstrap-icons.min.css';
 import './styles/backoffice.scss';
 import './stimulus.js';
 import './bootstrap.js';
+import * as Sentry from '@sentry/browser';
+
+const dsn = document.querySelector('meta[name="sentry-dsn"]')?.content ?? '';
+const userEmail = document.querySelector('meta[name="user-email"]')?.content ?? '';
+
+if (dsn) {
+    Sentry.init({
+        dsn,
+        integrations: [
+            Sentry.feedbackIntegration({
+                colorScheme: 'system',
+                showName: true,
+                showEmail: true,
+                isNameRequired: false,
+                isEmailRequired: false,
+            }),
+        ],
+    });
+
+    if (userEmail) {
+        Sentry.setUser({ email: userEmail });
+    }
+}

--- a/assets/backoffice.js
+++ b/assets/backoffice.js
@@ -8,21 +8,21 @@ import * as Sentry from '@sentry/browser';
 const dsn = document.querySelector('meta[name="sentry-dsn"]')?.content ?? '';
 const userEmail = document.querySelector('meta[name="user-email"]')?.content ?? '';
 
-if (dsn) {
-    Sentry.init({
-        dsn,
-        integrations: [
-            Sentry.feedbackIntegration({
-                colorScheme: 'system',
-                showName: true,
-                showEmail: true,
-                isNameRequired: false,
-                isEmailRequired: false,
-            }),
-        ],
-    });
+Sentry.init({
+    dsn: dsn || undefined,
+    // When no DSN is set (local dev), forward events to Spotlight instead
+    spotlight: !dsn,
+    integrations: [
+        Sentry.feedbackIntegration({
+            colorScheme: 'system',
+            showName: true,
+            showEmail: true,
+            isNameRequired: false,
+            isEmailRequired: false,
+        }),
+    ],
+});
 
-    if (userEmail) {
-        Sentry.setUser({ email: userEmail });
-    }
+if (userEmail) {
+    Sentry.setUser({ email: userEmail });
 }

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -70,5 +70,10 @@ services:
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
   ###< symfony/mailer ###
 
+  spotlight:
+    image: ghcr.io/getsentry/spotlight:latest
+    ports:
+      - "8969:8969"
+
 volumes:
   sass:

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -30,7 +30,7 @@ return [
     TwigExtraBundle::class => ['all' => true],
     DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     SymfonyCastsVerifyEmailBundle::class => ['all' => true],
-    SentryBundle::class => ['prod' => true],
+    SentryBundle::class => ['dev' => true, 'prod' => true],
     SymfonycastsSassBundle::class => ['all' => true],
     StimulusBundle::class => ['all' => true],
     TurboBundle::class => ['all' => true],

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -1,3 +1,9 @@
+when@dev:
+    sentry:
+        dsn: 'https://placeholder@placeholder.ingest.sentry.io/0'
+        options:
+            spotlight: 'http://spotlight:8969/stream'
+
 when@prod:
     sentry:
         dsn: '%env(SENTRY_DSN)%'

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -2,7 +2,8 @@ when@dev:
     sentry:
         dsn: 'https://placeholder@placeholder.ingest.sentry.io/0'
         options:
-            spotlight: 'http://spotlight:8969/stream'
+            spotlight: true
+            spotlight_url: 'http://spotlight:8969/stream'
 
 when@prod:
     sentry:

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,6 +1,8 @@
 twig:
     file_name_pattern: '*.twig'
     form_themes: [ 'bootstrap_5_layout.html.twig' ]
+    globals:
+        sentry_dsn: '%env(SENTRY_DSN)%'
 
 when@test:
     twig:

--- a/config/reference.php
+++ b/config/reference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // This file is auto-generated and is for apps only. Bundles SHOULD NOT rely on its content.
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
@@ -1518,6 +1520,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         web_profiler?: WebProfilerConfig,
  *         twig_extra?: TwigExtraConfig,
  *         symfonycasts_verify_email?: SymfonycastsVerifyEmailConfig,
+ *         sentry?: SentryConfig,
  *         symfonycasts_sass?: SymfonycastsSassConfig,
  *         stimulus?: StimulusConfig,
  *         turbo?: TurboConfig,

--- a/importmap.php
+++ b/importmap.php
@@ -34,4 +34,11 @@ return [
     '@hotwired/stimulus' => ['version' => '3.2.2'],
     '@hotwired/turbo' => ['version' => '8.0.23'],
     'bootstrap-icons/font/bootstrap-icons.min.css' => ['version' => '1.13.1', 'type' => 'css'],
+    '@sentry/browser' => ['version' => '10.63.0'],
+    '@sentry/feedback' => ['version' => '10.63.0'],
+    '@sentry/core/browser' => ['version' => '10.63.0'],
+    '@sentry/browser-utils' => ['version' => '10.63.0'],
+    '@sentry/replay' => ['version' => '10.63.0'],
+    '@sentry/replay-canvas' => ['version' => '10.63.0'],
+    '@sentry/core' => ['version' => '10.63.0'],
 ];

--- a/templates/backoffice/base.html.twig
+++ b/templates/backoffice/base.html.twig
@@ -1,5 +1,10 @@
 {% extends 'base.html.twig' %}
 {% block importmap %}{{ importmap('backoffice') }}{% endblock %}
+{% block sentry_loader %}{% endblock %}
+{% block head_extra %}
+    <meta name="sentry-dsn" content="{{ sentry_dsn }}">
+    <meta name="user-email" content="{{ app.user ? app.user.userIdentifier : '' }}">
+{% endblock %}
 {% block title %}Tijd voor de test | {% endblock %}
 {% block nav %}{{ include('backoffice/nav.html.twig') }}{% endblock %}
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,14 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% block sentry_loader %}
     <script
         src="https://js-de.sentry-cdn.com/30cf438bc708c97e6f45c127bed9af96.min.js"
         crossorigin="anonymous"
     ></script>
+    {% endblock %}
     <title>
         {% block title %}Tijd voor de test{% endblock title %}
     </title>
     {% block importmap %}{% endblock %}
+    {% block head_extra %}{% endblock %}
 </head>
 <body>
 {% block nav %}


### PR DESCRIPTION
## Summary

- Installs `@sentry/browser` v10 via AssetMapper (`importmap:require`)
- Initialises Sentry with `feedbackIntegration` on all backoffice pages, showing a floating feedback button
- Moves the existing CDN Sentry loader into an overridable Twig block; backoffice pages suppress it to avoid double-initialisation
- Exposes `SENTRY_DSN` as a Twig global so the JS SDK can read it from a `<meta>` tag — no-op when the DSN is empty
- Logged-in user's email is pre-filled via `Sentry.setUser()`; name and email fields are **optional**, so users can submit anonymously by clearing them

## Notes

- The widget will not render in dev unless `SENTRY_DSN` is set — this is expected behaviour and cannot be fully browser-tested locally without a real DSN
- `@sentry/replay` and `@sentry/replay-canvas` are listed in `importmap.php` as transitive dependencies of `@sentry/browser` but are not imported or activated

## Test plan

- [ ] Set `SENTRY_DSN` to a real Sentry project DSN in `.env.local`
- [ ] Log in to backoffice and confirm the feedback button appears
- [ ] Verify email field is pre-filled with the logged-in user's email
- [ ] Clear name/email and submit — confirm anonymous feedback arrives in Sentry with no user identity
- [ ] Submit with email filled — confirm user email is attached to the feedback event
- [ ] Verify the public quiz pages still have the CDN Sentry loader (not affected)

Closes #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side error monitoring to the backoffice, including an in-app feedback widget and optional user email context.
  * Exposed Sentry DSN and user email to templates, with a new template block to customise how the Sentry script is loaded.
  * Enabled Sentry spotlight tooling for development and added the spotlight service for local use.

* **Bug Fixes**
  * Extended Sentry configuration beyond production so error monitoring is available in development as well.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->