### PR TITLE
ci: auto-trigger main CI when tagging a Dependabot commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,14 +166,16 @@ jobs:
     timeout-minutes: 20
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
-      actions: read
+      actions: write
     steps:
       - name: Wait for and verify successful CI run on this commit
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          max_attempts=30
+          max_attempts=40
           attempt=0
+          triggered=false
+
           while [[ $attempt -lt $max_attempts ]]; do
             attempt=$((attempt + 1))
 
@@ -191,12 +193,32 @@ jobs:
               --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }}) | select(.status == \"in_progress\" or .status == \"queued\" or .status == \"waiting\" or .status == \"requested\" or .status == \"pending\")] | length")
 
             if [[ "$in_progress_count" -gt 0 ]]; then
-              echo "CI still in progress (attempt $attempt/$max_attempts), waiting 30s..."
+              echo "CI in progress (attempt $attempt/$max_attempts), waiting 30s..."
               sleep 30
-            else
-              echo "::error::No prior successful CI run found for ${{ github.sha }}. Only tag commits that have passed CI on main."
+              continue
+            fi
+
+            if [[ "$triggered" == "false" ]]; then
+              echo "No prior CI run found for ${{ github.sha }}. Triggering CI on main branch..."
+              gh workflow run ci.yml --repo "${{ github.repository }}" --ref main
+              triggered=true
+              echo "Triggered. Waiting 20s for run to register..."
+              sleep 20
+              continue
+            fi
+
+            failed_conclusion=$(gh api \
+              "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&per_page=10" \
+              --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }}) | select(.status == \"completed\") | select(.conclusion != \"success\")] | first | .conclusion // empty" \
+              --raw-output)
+
+            if [[ -n "$failed_conclusion" ]]; then
+              echo "::error::Triggered CI run on main failed with conclusion: $failed_conclusion. Fix the issue before re-tagging."
               exit 1
             fi
+
+            echo "Waiting for triggered run to register (attempt $attempt/$max_attempts)..."
+            sleep 20
           done
 
           echo "::error::Timed out waiting for CI run to complete for ${{ github.sha }}."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          max_attempts=40
+          max_attempts=30
           attempt=0
           triggered=false
 
@@ -199,8 +199,8 @@ jobs:
             fi
 
             if [[ "$triggered" == "false" ]]; then
-              echo "No prior CI run found for ${{ github.sha }}. Triggering CI on main branch..."
-              gh workflow run ci.yml --repo "${{ github.repository }}" --ref main
+              echo "No prior CI run found for ${{ github.sha }}. Triggering CI on ${{ github.ref }}..."
+              gh workflow run ci.yml --repo "${{ github.repository }}" --ref "${{ github.ref }}"
               triggered=true
               echo "Triggered. Waiting 20s for run to register..."
               sleep 20


### PR DESCRIPTION
## Problem

Dependabot auto-merges use `GITHUB_TOKEN` to push to `main`. GitHub intentionally does not re-trigger other workflows on such pushes (to prevent recursive runs). This means tagging a Dependabot bump commit immediately fails the `verify-prior-run` gate with *"No prior successful CI run found"*.

## Solution

Instead of hard-failing when no prior run exists, the job now:

1. Checks for a prior successful `ci.yml` run on the commit (same as before).
2. Waits if one is already in progress (same as before).
3. **New:** If neither exists, triggers `ci.yml` on `main` via `workflow_dispatch` and waits for it to complete.
4. **New:** If the triggered run fails, surfaces that conclusion with a clear error message.
5. Bumps the job permission from `actions: read` → `actions: write` to allow `gh workflow run`.

The `triggered` flag ensures we only dispatch once per tag run.

## Test plan

- [ ] Tag a Dependabot commit — verify the job now triggers and waits instead of instantly failing.
- [ ] Tag a normal commit that already has a successful main CI run — verify it still fast-paths (exits immediately on finding the prior run).
- [ ] If the triggered run fails, verify the error message names the failing conclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI handling for prior workflow runs on the main branch, reducing false starts and making failures easier to detect.
  * Added clearer retry and wait behaviour so pipeline checks are more reliable when a run is already in progress.

* **Chores**
  * Updated workflow permissions needed for the revised CI process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->