### PR TITLE
fix: trust X-Forwarded-Proto header from Traefik proxy

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -14,7 +14,7 @@ when@prod:
         # shortcut for private IP address ranges of your proxy
         trusted_proxies: 'private_ranges'
         # or, if your proxy instead uses the "Forwarded" header
-        trusted_headers: [ 'forwarded' ]
+        trusted_headers: [ 'x-forwarded-proto' ]
 
 when@test:
     framework:


### PR DESCRIPTION
## Summary

- Traefik terminates TLS and proxies requests to the app over HTTP internally, setting `X-Forwarded-Proto: https`
- Without trusting this header, Symfony generates `http://` URLs — surfaced by the password reset feature generating invalid links
- Changed `trusted_headers` from `forwarded` (RFC 7239 header, not sent by Traefik) to `x-forwarded-proto`

## Test plan

- [ ] Trigger a password reset email in production and confirm the link uses `https://`