### PR TITLE
fix: use global mailer From header for password reset email

### DIFF
--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -11,7 +11,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Address;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -132,7 +131,6 @@ final class ResetPasswordController extends AbstractController
         }
 
         $email = new TemplatedEmail()
-            ->from(new Address('info@tijdvoordetest.nl', 'Tijd voor de Test'))
             ->to($user->getUserIdentifier())
             ->subject($translator->trans('Your password reset request'))
             ->htmlTemplate('reset_password/email.html.twig')


### PR DESCRIPTION
## Summary

- Removes the hardcoded `->from(new Address('info@tijdvoordetest.nl', 'Tijd voor de Test'))` from `ResetPasswordController`
- The global `headers.From: 'Tijd voor de test <%env(MAILER_SENDER)%>'` in `mailer.yaml` now applies, using the correct `noreply@tijdvoordetest.nl` sender with the display name

## Test plan

- [ ] Set `MAILER_SENDER=Tijd voor de test <noreply@tijdvoordetest.nl>` in prod env
- [ ] Trigger a password reset email and verify the sender shows as "Tijd voor de test" in the mail client