### PR TITLE
feat: show active/ready badges on quiz list

### DIFF
--- a/templates/backoffice/season/tab_tests.html.twig
+++ b/templates/backoffice/season/tab_tests.html.twig
@@ -8,14 +8,14 @@
         </div>
         <div class="list-group mb-3">
             {% for quiz in season.quizzes %}
-                <a class="list-group-item list-group-item-action{% if season.activeQuiz == quiz %} active{% endif %}"
+                <a class="list-group-item list-group-item-action d-flex align-items-center gap-2{% if season.activeQuiz == quiz %} active{% endif %}"
                    href="{{ path('tvdt_backoffice_quiz', {seasonCode: season.seasonCode, quiz: quiz.id}) }}">
-                    {{ quiz.name }}
                     {% if season.activeQuiz == quiz %}
                         <span class="badge text-bg-light">{{ 'Active'|trans }}</span>
                     {% elseif quiz.isFinalized %}
                         <span class="badge text-bg-success">{{ 'Ready'|trans }}</span>
                     {% endif %}
+                    {{ quiz.name }}
                 </a>
             {% else %}
                 {{ 'No quizzes'|trans }}

--- a/templates/backoffice/season/tab_tests.html.twig
+++ b/templates/backoffice/season/tab_tests.html.twig
@@ -10,12 +10,12 @@
             {% for quiz in season.quizzes %}
                 <a class="list-group-item list-group-item-action d-flex align-items-center gap-2{% if season.activeQuiz == quiz %} active{% endif %}"
                    href="{{ path('tvdt_backoffice_quiz', {seasonCode: season.seasonCode, quiz: quiz.id}) }}">
-                    {% if season.activeQuiz == quiz %}
-                        <span class="badge text-bg-light">{{ 'Active'|trans }}</span>
-                    {% elseif quiz.isFinalized %}
-                        <span class="badge text-bg-success">{{ 'Ready'|trans }}</span>
-                    {% endif %}
                     {{ quiz.name }}
+                    {% if season.activeQuiz == quiz %}
+                        <span class="badge text-bg-light ms-auto">{{ 'Active'|trans }}</span>
+                    {% elseif quiz.isFinalized %}
+                        <span class="badge text-bg-success ms-auto">{{ 'Ready'|trans }}</span>
+                    {% endif %}
                 </a>
             {% else %}
                 {{ 'No quizzes'|trans }}

--- a/templates/backoffice/season/tab_tests.html.twig
+++ b/templates/backoffice/season/tab_tests.html.twig
@@ -11,8 +11,11 @@
                 <a class="list-group-item list-group-item-action{% if season.activeQuiz == quiz %} active{% endif %}"
                    href="{{ path('tvdt_backoffice_quiz', {seasonCode: season.seasonCode, quiz: quiz.id}) }}">
                     {{ quiz.name }}
+                    {% if season.activeQuiz == quiz %}
+                        <span class="badge text-bg-light">{{ 'Active'|trans }}</span>
+                    {% endif %}
                     {% if quiz.isFinalized %}
-                        <span class="badge text-bg-success">{{ 'Finalized'|trans }}</span>
+                        <span class="badge text-bg-success">{{ 'Ready'|trans }}</span>
                     {% endif %}
                 </a>
             {% else %}

--- a/templates/backoffice/season/tab_tests.html.twig
+++ b/templates/backoffice/season/tab_tests.html.twig
@@ -13,8 +13,7 @@
                     {{ quiz.name }}
                     {% if season.activeQuiz == quiz %}
                         <span class="badge text-bg-light">{{ 'Active'|trans }}</span>
-                    {% endif %}
-                    {% if quiz.isFinalized %}
+                    {% elseif quiz.isFinalized %}
                         <span class="badge text-bg-success">{{ 'Ready'|trans }}</span>
                     {% endif %}
                 </a>

--- a/translations/messages+intl-icu.nl.xliff
+++ b/translations/messages+intl-icu.nl.xliff
@@ -661,6 +661,10 @@
         <source>Re-opens the quiz for editing. Candidates will no longer be able to take the quiz until it is finalized again.</source>
         <target>Heropent de test voor bewerking. Deelnemers kunnen de test niet meer afnemen totdat deze opnieuw is afgerond.</target>
       </trans-unit>
+      <trans-unit id="MuwD4xO" resname="Ready">
+        <source>Ready</source>
+        <target>Voorbereid</target>
+      </trans-unit>
       <trans-unit id="P1HcfAu" resname="Red">
         <source>Red</source>
         <target>Rood</target>


### PR DESCRIPTION
## Summary
- Adds an "Active" badge to the quiz that is currently the season's active quiz.
- Renames the "Finalized" badge to "Ready" ("Voorbereid" in Dutch) for finalized quizzes.
- The "Ready" badge is hidden on the active quiz, since a quiz must be finalized before it can be made active, so showing both was redundant.

## Test plan
- [x] `just test`, `just phpstan`, `just fix-cs` — all pass
- [x] Manually verified in a browser against a temporary season/quizzes (cleaned up afterwards): active+finalized quiz shows only "Actief", finalized-but-inactive quiz shows "Voorbereid", neither badge shows otherwise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated quiz status labels in the back office so active quizzes now show **“Active”** and finalised quizzes now show **“Ready”** instead of **“Finalized”**.
* **Translation**
  * Added the Dutch translation for the new **“Ready”** label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->