### PR TITLE
feat: candidate rename and delete

### DIFF
--- a/src/Controller/Backoffice/SeasonController.php
+++ b/src/Controller/Backoffice/SeasonController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Constraints\Length;
@@ -28,6 +29,7 @@ use Tvdt\Enum\FlashType;
 use Tvdt\Form\AddCandidatesFormType;
 use Tvdt\Form\SettingsForm;
 use Tvdt\Form\UploadQuizFormType;
+use Tvdt\Repository\CandidateRepository;
 use Tvdt\Security\Voter\SeasonVoter;
 use Tvdt\Service\QuizSpreadsheetService;
 
@@ -39,6 +41,7 @@ class SeasonController extends AbstractController
         private readonly TranslatorInterface $translator,
         private readonly EntityManagerInterface $em,
         private readonly QuizSpreadsheetService $quizSpreadsheet,
+        private readonly CandidateRepository $candidateRepository,
     ) {}
 
     #[IsGranted(SeasonVoter::EDIT, subject: 'season')]
@@ -141,6 +144,56 @@ class SeasonController extends AbstractController
         }
 
         return $this->render('backoffice/season_add_candidates.html.twig', ['form' => $form, 'season' => $season]);
+    }
+
+    #[IsCsrfTokenValid('rename_candidate')]
+    #[IsGranted(SeasonVoter::EDIT, subject: 'candidate')]
+    #[Route(
+        '/backoffice/season/{seasonCode:season}/candidate/{candidate}/rename',
+        name: 'tvdt_backoffice_candidate_rename',
+        requirements: ['seasonCode' => self::SEASON_CODE_REGEX, 'candidate' => Requirement::UUID],
+        methods: ['POST'],
+    )]
+    public function renameCandidate(Season $season, Candidate $candidate, Request $request): RedirectResponse
+    {
+        $name = mb_trim($request->request->getString('name'));
+
+        if ('' === $name || mb_strlen($name) > 16) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('The candidate name must be between 1 and 16 characters'));
+
+            return $this->redirectToRoute('tvdt_backoffice_season_candidates', ['seasonCode' => $season->seasonCode]);
+        }
+
+        $candidate->name = $name;
+
+        try {
+            $this->em->flush();
+        } catch (UniqueConstraintViolationException) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('A candidate with this name already exists in this season'));
+
+            return $this->redirectToRoute('tvdt_backoffice_season_candidates', ['seasonCode' => $season->seasonCode]);
+        }
+
+        $this->addFlash(FlashType::Success, $this->translator->trans('Candidate renamed'));
+
+        return $this->redirectToRoute('tvdt_backoffice_season_candidates', ['seasonCode' => $season->seasonCode]);
+    }
+
+    #[IsCsrfTokenValid('delete_candidate')]
+    #[IsGranted(SeasonVoter::DELETE, subject: 'candidate')]
+    #[Route(
+        '/backoffice/season/{seasonCode:season}/candidate/{candidate}/delete',
+        name: 'tvdt_backoffice_candidate_delete',
+        requirements: ['seasonCode' => self::SEASON_CODE_REGEX, 'candidate' => Requirement::UUID],
+        methods: ['POST'],
+    )]
+    public function deleteCandidate(Season $season, Candidate $candidate): RedirectResponse
+    {
+        $this->candidateRepository->deleteCandidate($candidate);
+
+        $this->addFlash(FlashType::Success, $this->translator->trans('Candidate deleted'));
+
+        return $this->redirectToRoute('tvdt_backoffice_season_candidates', ['seasonCode' => $season->seasonCode]);
     }
 
     #[IsGranted(SeasonVoter::EDIT, subject: 'season')]

--- a/src/Repository/CandidateRepository.php
+++ b/src/Repository/CandidateRepository.php
@@ -19,6 +19,12 @@ class CandidateRepository extends ServiceEntityRepository
         parent::__construct($registry, Candidate::class);
     }
 
+    public function deleteCandidate(Candidate $candidate): void
+    {
+        $this->getEntityManager()->remove($candidate);
+        $this->getEntityManager()->flush();
+    }
+
     public function getCandidateByHash(Season $season, string $hash): ?Candidate
     {
         try {

--- a/templates/backoffice/help/nl/season_candidates.html.twig
+++ b/templates/backoffice/help/nl/season_candidates.html.twig
@@ -1,3 +1,4 @@
 <h6>Kandidaten</h6>
 <p>Dit zijn de spelers van dit seizoen. Voeg alle deelnemers toe voordat je de eerste test start, kandidaten worden automatisch aan nieuwe testen gekoppeld.</p>
 <p>Namen zijn vrij in te voeren, gebruik dezelfde schrijfwijze die je in het spel gebruikt.</p>
+<p>Gebruik het potlood-icoon om een kandidaat te hernoemen en het prullenbak-icoon om er een te verwijderen. Verwijderen gooit ook alle gegeven antwoorden van die kandidaat weg.</p>

--- a/templates/backoffice/season/tab_candidates.html.twig
+++ b/templates/backoffice/season/tab_candidates.html.twig
@@ -4,9 +4,67 @@
             <a class="btn btn-sm btn-outline-primary"
                href="{{ path('tvdt_backoffice_add_candidates', {seasonCode: season.seasonCode}) }}">{{ 'Add Candidate'|trans }}</a>
         </div>
-        <ul class="mb-3">
+        <ul class="list-group mb-3">
             {% for candidate in season.candidates %}
-                <li>{{ candidate.name }}</li>
+                <li class="list-group-item d-flex align-items-center justify-content-between gap-2">
+                    {{ candidate.name }}
+                    <div class="btn-group btn-group-sm" role="group">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal"
+                                data-bs-target="#renameCandidate-{{ candidate.id }}"
+                                title="{{ 'Rename'|trans }}"><i class="bi bi-pencil"></i></button>
+                        <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal"
+                                data-bs-target="#deleteCandidate-{{ candidate.id }}"
+                                title="{{ 'Delete'|trans }}"><i class="bi bi-trash"></i></button>
+                    </div>
+
+                    <div class="modal fade" id="renameCandidate-{{ candidate.id }}" data-bs-backdrop="static"
+                         tabindex="-1" aria-labelledby="renameCandidate-{{ candidate.id }}Label" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <form action="{{ path('tvdt_backoffice_candidate_rename', {seasonCode: season.seasonCode, candidate: candidate.id}) }}"
+                                      method="POST">
+                                    <div class="modal-header">
+                                        <h1 class="modal-title fs-5" id="renameCandidate-{{ candidate.id }}Label">{{ 'Rename candidate'|trans }}</h1>
+                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                    </div>
+                                    <div class="modal-body text-start">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('rename_candidate') }}">
+                                        <label class="form-label" for="renameCandidateName-{{ candidate.id }}">{{ 'Name'|trans }}</label>
+                                        <input type="text" class="form-control" id="renameCandidateName-{{ candidate.id }}"
+                                               name="name" value="{{ candidate.name }}" maxlength="16" required autofocus>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
+                                        <button type="submit" class="btn btn-primary">{{ 'Rename'|trans }}</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="modal fade" id="deleteCandidate-{{ candidate.id }}" data-bs-backdrop="static"
+                         tabindex="-1" aria-labelledby="deleteCandidate-{{ candidate.id }}Label" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h1 class="modal-title fs-5" id="deleteCandidate-{{ candidate.id }}Label">{{ 'Please Confirm'|trans }}</h1>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                </div>
+                                <div class="modal-body text-start">
+                                    {{ 'Are you sure you want to delete this candidate? All their answers will be lost.'|trans }}
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'No'|trans }}</button>
+                                    <form action="{{ path('tvdt_backoffice_candidate_delete', {seasonCode: season.seasonCode, candidate: candidate.id}) }}"
+                                          method="POST">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('delete_candidate') }}">
+                                        <button type="submit" class="btn btn-danger">{{ 'Yes'|trans }}</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </li>
             {% else %}
                 {{ 'No candidates'|trans }}
             {% endfor %}

--- a/tests/Controller/Backoffice/SeasonControllerTest.php
+++ b/tests/Controller/Backoffice/SeasonControllerTest.php
@@ -10,6 +10,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Tvdt\Controller\Backoffice\SeasonController;
+use Tvdt\Entity\Candidate;
 use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
 
@@ -63,6 +64,94 @@ final class SeasonControllerTest extends WebTestCase
 
         $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/regenerate-code', [
             '_token' => $token,
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    private function getCandidate(string $name): Candidate
+    {
+        $candidate = $this->entityManager->getRepository(Candidate::class)->findOneBy(['name' => $name]);
+        $this->assertInstanceOf(Candidate::class, $candidate);
+
+        return $candidate;
+    }
+
+    private function getCsrfTokenFromCandidatesTab(string $formActionContains): string
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/backoffice/season/krtek/candidates');
+        self::assertResponseIsSuccessful();
+
+        $input = $crawler->filter(\sprintf('form[action*="%s"] input[name="_token"]', $formActionContains));
+        $this->assertGreaterThan(0, $input->count(), \sprintf('No form found with action containing "%s"', $formActionContains));
+
+        return (string) $input->first()->attr('value');
+    }
+
+    public function testRenameCandidate(): void
+    {
+        $candidate = $this->getCandidate('Tom');
+        $token = $this->getCsrfTokenFromCandidatesTab(\sprintf('/candidate/%s/rename', $candidate->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/candidate/%s/rename', $candidate->id), [
+            '_token' => $token,
+            'name' => 'Tommy',
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/candidates');
+        $this->entityManager->clear();
+
+        $renamed = $this->entityManager->getRepository(Candidate::class)->find($candidate->id);
+        $this->assertInstanceOf(Candidate::class, $renamed);
+        $this->assertSame('Tommy', $renamed->name);
+    }
+
+    public function testRenameCandidateToExistingNameShowsError(): void
+    {
+        $candidate = $this->getCandidate('Tom');
+        $token = $this->getCsrfTokenFromCandidatesTab(\sprintf('/candidate/%s/rename', $candidate->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/candidate/%s/rename', $candidate->id), [
+            '_token' => $token,
+            'name' => 'Claudia',
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/candidates');
+        $this->entityManager->clear();
+
+        $unchanged = $this->entityManager->getRepository(Candidate::class)->find($candidate->id);
+        $this->assertInstanceOf(Candidate::class, $unchanged);
+        $this->assertSame('Tom', $unchanged->name);
+    }
+
+    public function testDeleteCandidate(): void
+    {
+        $candidate = $this->getCandidate('Tom');
+        $candidateId = $candidate->id;
+        $token = $this->getCsrfTokenFromCandidatesTab(\sprintf('/candidate/%s/delete', $candidate->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/candidate/%s/delete', $candidate->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/candidates');
+        $this->entityManager->clear();
+
+        $this->assertNotInstanceOf(Candidate::class, $this->entityManager->getRepository(Candidate::class)->find($candidateId));
+    }
+
+    public function testRenameCandidateIsDeniedForNonOwner(): void
+    {
+        $candidate = $this->getCandidate('Tom');
+        $token = $this->getCsrfTokenFromCandidatesTab(\sprintf('/candidate/%s/rename', $candidate->id));
+
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'test@example.org']);
+        $this->assertInstanceOf(User::class, $user);
+        $this->client->loginUser($user);
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/candidate/%s/rename', $candidate->id), [
+            '_token' => $token,
+            'name' => 'Tommy',
         ]);
 
         self::assertResponseStatusCodeSame(403);

--- a/translations/messages+intl-icu.nl.xliff
+++ b/translations/messages+intl-icu.nl.xliff
@@ -5,6 +5,10 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
+      <trans-unit id="QcFeGZy" resname="A candidate with this name already exists in this season">
+        <source>A candidate with this name already exists in this season</source>
+        <target>Er bestaat al een kandidaat met deze naam in dit seizoen</target>
+      </trans-unit>
       <trans-unit id="VNxXghX" resname="A label with a similar name already exists">
         <source>A label with a similar name already exists</source>
         <target>Er bestaat al een label met deze naam</target>
@@ -101,6 +105,10 @@
         <source>Are you sure you want to clear all the results? This will also delete all the eliminations.</source>
         <target>Weet je zeker dat je de resultaten wilt leegmaken? Dit gooit ook alle eliminaties weg.</target>
       </trans-unit>
+      <trans-unit id="zisWo9d" resname="Are you sure you want to delete this candidate? All their answers will be lost.">
+        <source>Are you sure you want to delete this candidate? All their answers will be lost.</source>
+        <target>Weet je zeker dat je deze kandidaat wilt verwijderen? Alle gegeven antwoorden gaan dan verloren.</target>
+      </trans-unit>
       <trans-unit id="8HZ5s3T" resname="Are you sure you want to delete this question from the question bank?">
         <source>Are you sure you want to delete this question from the question bank?</source>
         <target>Weet je zeker dat je deze vraag uit de vragenbank wilt verwijderen?</target>
@@ -145,9 +153,17 @@
         <source>Candidate answers saved</source>
         <target>Kandidaatantwoorden opgeslagen</target>
       </trans-unit>
+      <trans-unit id="tggdgJl" resname="Candidate deleted">
+        <source>Candidate deleted</source>
+        <target>Kandidaat verwijderd</target>
+      </trans-unit>
       <trans-unit id="TiTLBGW" resname="Candidate not found">
         <source>Candidate not found</source>
         <target>Kandidaat niet gevonden</target>
+      </trans-unit>
+      <trans-unit id="QH4e_Ho" resname="Candidate renamed">
+        <source>Candidate renamed</source>
+        <target>Kandidaat hernoemd</target>
       </trans-unit>
       <trans-unit id="6QiGbuz" resname="Candidate status updated">
         <source>Candidate status updated</source>
@@ -697,6 +713,14 @@
         <source>Remove label</source>
         <target>Label verwijderen</target>
       </trans-unit>
+      <trans-unit id="WHywg0z" resname="Rename">
+        <source>Rename</source>
+        <target>Hernoemen</target>
+      </trans-unit>
+      <trans-unit id="K2RP6H8" resname="Rename candidate">
+        <source>Rename candidate</source>
+        <target>Kandidaat hernoemen</target>
+      </trans-unit>
       <trans-unit id="Z9CSKpk" resname="Repeat Password">
         <source>Repeat Password</source>
         <target>Herhaal wachtwoord</target>
@@ -792,6 +816,10 @@
       <trans-unit id="yqJbSKu" resname="Sync latest changes to this quiz">
         <source>Sync latest changes to this quiz</source>
         <target>Laatste wijzigingen synchroniseren naar deze quiz</target>
+      </trans-unit>
+      <trans-unit id="cug5d45" resname="The candidate name must be between 1 and 16 characters">
+        <source>The candidate name must be between 1 and 16 characters</source>
+        <target>De naam van de kandidaat moet tussen de 1 en 16 tekens zijn</target>
       </trans-unit>
       <trans-unit id="XwQ1Fav" resname="The confirmation email could not be sent. Please try again later.">
         <source>The confirmation email could not be sent. Please try again later.</source>


### PR DESCRIPTION
## Summary
- Adds "Rename" and "Delete" actions per candidate on the candidates tab, each behind a confirmation modal (mirrors the existing delete-quiz/delete-bank-question pattern).
- New POST routes `tvdt_backoffice_candidate_rename` and `tvdt_backoffice_candidate_delete`, CSRF-protected and gated by `SeasonVoter::EDIT`/`SeasonVoter::DELETE` on the `Candidate` subject.
- Renaming validates length (1-16 chars) and handles the unique `(name, season)` constraint with a flash error on collision.
- Deleting a candidate cascades to their given answers and quiz participation via existing `orphanRemoval` settings on the entity (same approach as quiz deletion).
- Updated the Dutch help text and ran `just translations` for the new strings.

Closes #18

## Test plan
- [x] `just test tests/Controller/Backoffice/SeasonControllerTest.php` — new tests cover rename, rename-collision (no-op + error), delete, and voter denial for non-owners
- [x] `just test` — full suite passes (182 tests)
- [x] `just phpstan`, `just rector --dry-run`, `just fix-cs` — all clean
- [x] Manually verified in a browser against a temporary season/candidates (cleaned up afterwards): rename modal pre-fills the current name and updates the list with a success flash; delete modal confirms before removing the candidate with a success flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backoffice users can now rename and delete candidates directly from the season candidates list.
  * Added confirmation dialogs and clearer action buttons for candidate management.

* **Bug Fixes**
  * Improved validation for candidate names, including length limits and duplicate-name handling.
  * Added clearer feedback when candidate actions succeed or fail.

* **Documentation**
  * Updated help text to explain how to rename or delete a candidate and note that deletion removes their answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->