### PR TITLE
feat: add GDPR data export (download data) button

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/security-bundle": "8.1.*",
         "symfony/security-csrf": "8.1.*",
         "symfony/serializer": "8.1.*",
+        "symfony/string": "8.1.*",
         "symfony/translation": "8.1.*",
         "symfony/twig-bundle": "8.1.*",
         "symfony/uid": "8.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "010a4456ebc1a8ebaf73c6db051d3d09",
+    "content-hash": "ccae654dd9c952e8920d9cb9c0f35ff5",
     "packages": [
         {
             "name": "composer/pcre",

--- a/src/Controller/Backoffice/BackofficeController.php
+++ b/src/Controller/Backoffice/BackofficeController.php
@@ -18,6 +18,7 @@ use Tvdt\Controller\AbstractController;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Form\CreateSeasonFormType;
+use Tvdt\Helpers\FilenameSanitizer;
 use Tvdt\Repository\SeasonRepository;
 use Tvdt\Security\Voter\SeasonVoter;
 use Tvdt\Service\QuizSpreadsheetService;
@@ -87,7 +88,7 @@ final class BackofficeController extends AbstractController
     {
         $response = new StreamedResponse($this->excel->quizToXlsx($quiz));
         $response->headers->set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-        $response->headers->set('Content-Disposition', HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $quiz->name.'.xlsx'));
+        $response->headers->set('Content-Disposition', HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, FilenameSanitizer::sanitize($quiz->name).'.xlsx'));
 
         return $response;
     }

--- a/src/Controller/Backoffice/BackofficeController.php
+++ b/src/Controller/Backoffice/BackofficeController.php
@@ -14,9 +14,11 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Tvdt\Controller\AbstractController;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
+use Tvdt\Enum\FlashType;
 use Tvdt\Form\CreateSeasonFormType;
 use Tvdt\Helpers\FilenameSanitizer;
 use Tvdt\Repository\SeasonRepository;
@@ -32,6 +34,7 @@ final class BackofficeController extends AbstractController
         private readonly Security $security,
         private readonly QuizSpreadsheetService $excel,
         private readonly EntityManagerInterface $em,
+        private readonly TranslatorInterface $translator,
     ) {}
 
     #[Route('/backoffice/', name: 'tvdt_backoffice_index')]
@@ -84,8 +87,14 @@ final class BackofficeController extends AbstractController
         requirements: ['quiz' => Requirement::UUID],
         methods: ['GET'],
     )]
-    public function exportQuiz(Quiz $quiz): StreamedResponse
+    public function exportQuiz(Quiz $quiz): Response
     {
+        if (!$this->authenticatedUser->isVerified) {
+            $this->addFlash(FlashType::Warning, $this->translator->trans('Please confirm your email address before exporting a quiz.'));
+
+            return $this->redirectToRoute('tvdt_backoffice_season', ['seasonCode' => $quiz->season->seasonCode]);
+        }
+
         $response = new StreamedResponse($this->excel->quizToXlsx($quiz));
         $response->headers->set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         $response->headers->set('Content-Disposition', HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, FilenameSanitizer::sanitize($quiz->name).'.xlsx'));

--- a/src/Controller/Backoffice/SettingsController.php
+++ b/src/Controller/Backoffice/SettingsController.php
@@ -24,6 +24,7 @@ use Tvdt\Entity\User;
 use Tvdt\Enum\FlashType;
 use Tvdt\Form\ChangeEmailFormType;
 use Tvdt\Form\ChangeUserPasswordFormType;
+use Tvdt\Helpers\FilenameSanitizer;
 use Tvdt\Repository\UserRepository;
 use Tvdt\Security\EmailVerifier;
 use Tvdt\Service\DataExportService;
@@ -160,7 +161,7 @@ final class SettingsController extends AbstractController
 
         $filename = \sprintf(
             'tijd-voor-de-test-data-%s-%s.zip',
-            DataExportService::sanitizeForPath($this->authenticatedUser->email),
+            FilenameSanitizer::sanitize($this->authenticatedUser->email),
             new DateTimeImmutable()->format('Y-m-d_H-i-s'),
         );
 

--- a/src/Controller/Backoffice/SettingsController.php
+++ b/src/Controller/Backoffice/SettingsController.php
@@ -155,8 +155,14 @@ final class SettingsController extends AbstractController
     }
 
     #[Route('/backoffice/settings/download-data', name: 'tvdt_backoffice_settings_download_data', methods: ['GET'])]
-    public function downloadData(): BinaryFileResponse
+    public function downloadData(): Response
     {
+        if (!$this->authenticatedUser->isVerified) {
+            $this->addFlash(FlashType::Warning, $this->translator->trans('Please confirm your email address before downloading your data.'));
+
+            return $this->redirectToRoute('tvdt_backoffice_settings');
+        }
+
         $zipPath = $this->dataExportService->exportForUser($this->authenticatedUser);
 
         $filename = \sprintf(

--- a/src/Controller/Backoffice/SettingsController.php
+++ b/src/Controller/Backoffice/SettingsController.php
@@ -6,9 +6,12 @@ namespace Tvdt\Controller\Backoffice;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
+use Safe\DateTimeImmutable;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,6 +26,7 @@ use Tvdt\Form\ChangeEmailFormType;
 use Tvdt\Form\ChangeUserPasswordFormType;
 use Tvdt\Repository\UserRepository;
 use Tvdt\Security\EmailVerifier;
+use Tvdt\Service\DataExportService;
 
 final class SettingsController extends AbstractController
 {
@@ -33,6 +37,7 @@ final class SettingsController extends AbstractController
         private readonly EmailVerifier $emailVerifier,
         private readonly Security $security,
         private readonly TranslatorInterface $translator,
+        private readonly DataExportService $dataExportService,
     ) {}
 
     #[Route('/backoffice/settings', name: 'tvdt_backoffice_settings', methods: ['GET'])]
@@ -146,6 +151,28 @@ final class SettingsController extends AbstractController
         }
 
         return $this->redirectToRoute('tvdt_backoffice_settings');
+    }
+
+    #[Route('/backoffice/settings/download-data', name: 'tvdt_backoffice_settings_download_data', methods: ['GET'])]
+    public function downloadData(): BinaryFileResponse
+    {
+        $zipPath = $this->dataExportService->exportForUser($this->authenticatedUser);
+
+        $filename = \sprintf(
+            'tijd-voor-de-test-data-%s-%s.zip',
+            DataExportService::sanitizeForPath($this->authenticatedUser->email),
+            new DateTimeImmutable()->format('Y-m-d_H-i-s'),
+        );
+
+        $response = new BinaryFileResponse($zipPath);
+        $response->deleteFileAfterSend(true);
+        $response->headers->set('Content-Type', 'application/zip');
+        $response->headers->set(
+            'Content-Disposition',
+            HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $filename),
+        );
+
+        return $response;
     }
 
     #[IsCsrfTokenValid('delete_account')]

--- a/src/Helpers/FilenameSanitizer.php
+++ b/src/Helpers/FilenameSanitizer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Helpers;
+
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+class FilenameSanitizer
+{
+    /** Slugs user-supplied text (e.g. a season/quiz name) into a string safe to use as a zip entry path segment or a downloaded filename. */
+    public static function sanitize(string $value): string
+    {
+        $slug = new AsciiSlugger()->slug($value)->toString();
+
+        return '' === $slug ? 'unnamed' : $slug;
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace Tvdt\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Tvdt\Entity\BankQuestion;
+use Tvdt\Entity\Elimination;
+use Tvdt\Entity\GivenAnswer;
+use Tvdt\Entity\QuizCandidate;
+use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
 
 /** @extends ServiceEntityRepository<User> */
@@ -44,8 +50,11 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $em->wrapInTransaction(function () use ($em, $user): void {
             $this->invalidateResetPasswordRequests($user);
 
+            $bankQuestionIds = [];
             foreach ($user->seasons->toArray() as $season) {
                 if (1 === $season->owners->count()) {
+                    $this->purgeSoftDeletableData($em, $season);
+                    array_push($bankQuestionIds, ...$this->bankQuestionIds($season));
                     $em->remove($season);
 
                     continue;
@@ -56,7 +65,61 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
 
             $em->remove($user);
             $em->flush();
+
+            // Gedmo\Loggable writes its own "removed" log entry as part of the flush above, so the
+            // audit-log purge must happen after — purging first would just leave that final row behind.
+            $this->purgeBankQuestionAuditLog($em, $bankQuestionIds);
         });
+    }
+
+    /**
+     * QuizCandidate, GivenAnswer, and Elimination are Gedmo\SoftDeleteable, so cascading their
+     * removal through the season/quiz/candidate relations only sets deletedAt — it never removes
+     * the row. That leaves personal data behind indefinitely and, since Candidate/Answer are hard
+     * deleted via orphanRemoval, it also breaks their foreign keys and rolls back the whole
+     * deletion. Bulk DQL deletes bypass the Gedmo listener and physically remove these rows first.
+     */
+    private function purgeSoftDeletableData(EntityManagerInterface $em, Season $season): void
+    {
+        foreach ([QuizCandidate::class, GivenAnswer::class, Elimination::class] as $class) {
+            $em->createQuery(<<<DQL
+                delete from {$class} e
+                where e.quiz in (select q from Tvdt\Entity\Quiz q where q.season = :season)
+                DQL)
+                ->setParameter('season', $season)
+                ->execute();
+        }
+    }
+
+    /** @return list<string> */
+    private function bankQuestionIds(Season $season): array
+    {
+        return array_values(array_map(
+            static fn (BankQuestion $bankQuestion): string => $bankQuestion->id->toString(),
+            $season->bankQuestions->toArray(),
+        ));
+    }
+
+    /**
+     * Gedmo\Loggable audit rows (ext_log_entries) aren't foreign-keyed to the entity they log —
+     * object_id is a plain string — so removing a BankQuestion never cleans up its history, and
+     * the editor's username/email would otherwise remain in those rows forever.
+     *
+     * @param list<string> $bankQuestionIds
+     */
+    private function purgeBankQuestionAuditLog(EntityManagerInterface $em, array $bankQuestionIds): void
+    {
+        if ([] === $bankQuestionIds) {
+            return;
+        }
+
+        $em->createQuery(<<<'DQL'
+            delete from Tvdt\Entity\LogEntry l
+            where l.objectClass = :class and l.objectId in (:ids)
+            DQL)
+            ->setParameter('class', BankQuestion::class)
+            ->setParameter('ids', $bankQuestionIds)
+            ->execute();
     }
 
     public function makeAdmin(string $email): void

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -143,7 +143,11 @@ class DataExportService
     {
         $spreadsheet = new Spreadsheet();
 
-        $questions = $spreadsheet->getActiveSheet();
+        $info = $spreadsheet->getActiveSheet();
+        $info->setTitle('Quiz info');
+        $this->fillQuizInfoSheet($info, $quiz);
+
+        $questions = $spreadsheet->createSheet();
         $questions->setTitle('Questions');
 
         $this->quizSpreadsheetService->fillQuestionsSheet($questions, $quiz);
@@ -163,6 +167,25 @@ class DataExportService
         $spreadsheet->setActiveSheetIndex(0);
 
         return $spreadsheet;
+    }
+
+    private function fillQuizInfoSheet(Worksheet $sheet, Quiz $quiz): void
+    {
+        $disabledQuestions = $quiz->questions
+            ->filter(static fn (Question $question): bool => !$question->enabled)
+            ->map(static fn (Question $question): string => $question->question)
+            ->toArray();
+
+        $sheet->getStyle('A:A')->getFont()->setBold(true);
+        $sheet->fromArray([
+            ['Quiz name', $quiz->name],
+            ['Number of dropouts', $quiz->dropouts],
+            ['Finalized', $quiz->isFinalized ? 'Yes' : 'No'],
+            ['Finalized at', $quiz->finalizedAt?->format(\DateTimeInterface::ATOM) ?? ''],
+            ['Disabled questions', implode(', ', $disabledQuestions)],
+        ], null, 'A1');
+        $sheet->getColumnDimension('A')->setAutoSize(true);
+        $sheet->getColumnDimension('B')->setAutoSize(true);
     }
 
     private function fillResultsSheet(Worksheet $sheet, Quiz $quiz): void

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -18,9 +18,9 @@ use Tvdt\Entity\QuestionLabel;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
+use Tvdt\Helpers\FilenameSanitizer;
 use Tvdt\Repository\QuizRepository;
 
-use function Safe\preg_replace;
 use function Safe\tempnam;
 use function Safe\unlink;
 
@@ -60,12 +60,12 @@ class DataExportService
             $zip->addFile($profilePath, 'profile.xlsx');
 
             foreach ($user->seasons as $season) {
-                $folder = self::sanitizeForPath($season->seasonCode.'-'.$season->name).'/';
+                $folder = FilenameSanitizer::sanitize($season->seasonCode.'-'.$season->name).'/';
 
                 foreach ($season->quizzes as $quiz) {
                     $quizPath = $this->writeToTempFile($this->buildQuizWorkbook($quiz));
                     $tempXlsxFiles[] = $quizPath;
-                    $zip->addFile($quizPath, $folder.self::sanitizeForPath($quiz->name).'.xlsx');
+                    $zip->addFile($quizPath, $folder.FilenameSanitizer::sanitize($quiz->name).'.xlsx');
                 }
 
                 $candidatesPath = $this->writeToTempFile($this->buildCandidatesWorkbook($season));
@@ -401,14 +401,5 @@ class DataExportService
         new Writer\Xlsx($spreadsheet)->save($path);
 
         return $path;
-    }
-
-    /** Strips characters that are unsafe in a zip entry name or a downloaded filename (path separators, traversal, control characters). */
-    public static function sanitizeForPath(string $value): string
-    {
-        $sanitized = preg_replace('#[\\\\/:*?"<>|\x00-\x1F]+#', '-', $value);
-        $sanitized = mb_trim($sanitized, " .\t\n\r\0\x0B-");
-
-        return '' === $sanitized ? 'unnamed' : $sanitized;
     }
 }

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -52,7 +52,11 @@ class DataExportService
         $tempXlsxFiles = [];
 
         $zip = new \ZipArchive();
-        $zip->open($zipPath, \ZipArchive::OVERWRITE);
+        if (true !== $zip->open($zipPath, \ZipArchive::OVERWRITE)) {
+            unlink($zipPath);
+
+            throw new \RuntimeException('Could not create the export zip archive.');
+        }
 
         try {
             $profilePath = $this->writeToTempFile($this->buildProfileWorkbook($user));
@@ -77,7 +81,13 @@ class DataExportService
                 $zip->addFile($questionBankPath, $folder.'question-bank.xlsx');
             }
 
-            $zip->close();
+            if (!$zip->close()) {
+                throw new \RuntimeException('Could not finalize the export zip archive.');
+            }
+        } catch (\Throwable $throwable) {
+            unlink($zipPath);
+
+            throw $throwable;
         } finally {
             foreach ($tempXlsxFiles as $tempXlsxFile) {
                 unlink($tempXlsxFile);
@@ -398,7 +408,14 @@ class DataExportService
     private function writeToTempFile(Spreadsheet $spreadsheet): string
     {
         $path = tempnam(sys_get_temp_dir(), 'tvdt_export_sheet_');
-        new Writer\Xlsx($spreadsheet)->save($path);
+
+        try {
+            new Writer\Xlsx($spreadsheet)->save($path);
+        } catch (\Throwable $throwable) {
+            unlink($path);
+
+            throw $throwable;
+        }
 
         return $path;
     }

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PhpOffice\PhpSpreadsheet\Writer;
+use Safe\Exceptions\FilesystemException;
+use Tvdt\Dto\Result;
+use Tvdt\Entity\Candidate;
+use Tvdt\Entity\Quiz;
+use Tvdt\Entity\Season;
+use Tvdt\Entity\User;
+use Tvdt\Repository\QuizRepository;
+
+use function Safe\preg_replace;
+use function Safe\tempnam;
+use function Safe\unlink;
+
+/** Builds a GDPR data-portability export (a zip of xlsx files) for everything owned by a single user. */
+class DataExportService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly QuizSpreadsheetService $quizSpreadsheetService,
+        private readonly QuizRepository $quizRepository,
+    ) {}
+
+    /** @throws FilesystemException @return string path to a temp zip file; caller is responsible for removing it */
+    public function exportForUser(User $user): string
+    {
+        $filter = $this->entityManager->getFilters();
+        $filter->disable('softdeleteable');
+
+        try {
+            return $this->buildZip($user);
+        } finally {
+            $filter->enable('softdeleteable');
+        }
+    }
+
+    private function buildZip(User $user): string
+    {
+        $zipPath = tempnam(sys_get_temp_dir(), 'tvdt_export_');
+        $tempXlsxFiles = [];
+
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::OVERWRITE);
+
+        try {
+            $profilePath = $this->writeToTempFile($this->buildProfileWorkbook($user));
+            $tempXlsxFiles[] = $profilePath;
+            $zip->addFile($profilePath, 'profile.xlsx');
+
+            foreach ($user->seasons as $season) {
+                $folder = self::sanitizeForPath($season->seasonCode.'-'.$season->name).'/';
+
+                foreach ($season->quizzes as $quiz) {
+                    $quizPath = $this->writeToTempFile($this->buildQuizWorkbook($quiz));
+                    $tempXlsxFiles[] = $quizPath;
+                    $zip->addFile($quizPath, $folder.self::sanitizeForPath($quiz->name).'.xlsx');
+                }
+
+                $candidatesPath = $this->writeToTempFile($this->buildCandidatesWorkbook($season));
+                $tempXlsxFiles[] = $candidatesPath;
+                $zip->addFile($candidatesPath, $folder.'candidates.xlsx');
+            }
+
+            $zip->close();
+        } finally {
+            foreach ($tempXlsxFiles as $tempXlsxFile) {
+                unlink($tempXlsxFile);
+            }
+        }
+
+        return $zipPath;
+    }
+
+    private function buildProfileWorkbook(User $user): Spreadsheet
+    {
+        $spreadsheet = new Spreadsheet();
+
+        $account = $spreadsheet->getActiveSheet();
+        $account->setTitle('Account');
+        $account->getStyle('A:A')->getFont()->setBold(true);
+        $account->fromArray([
+            ['Email', $user->email],
+            ['Roles', implode(', ', $user->getRoles())],
+            ['Email verified', $user->isVerified ? 'Yes' : 'No'],
+            ['Account ID', $user->id->toString()],
+        ], null, 'A1');
+        $account->getColumnDimension('A')->setAutoSize(true);
+        $account->getColumnDimension('B')->setAutoSize(true);
+
+        $seasons = $spreadsheet->createSheet();
+        $seasons->setTitle('Seasons');
+        $seasons->fromArray(['Season', 'Season code', 'Quizzes', 'Candidates', 'Shared with other owners'], null, 'A1');
+        $seasons->getStyle('1:1')->getFont()->setBold(true);
+
+        $row = 2;
+        foreach ($user->seasons as $season) {
+            $seasons->fromArray([
+                $season->name,
+                $season->seasonCode,
+                $season->quizzes->count(),
+                $season->candidates->count(),
+                $season->owners->count() > 1 ? 'Yes' : 'No',
+            ], null, 'A'.$row);
+            ++$row;
+        }
+
+        foreach (['A', 'B', 'C', 'D', 'E'] as $column) {
+            $seasons->getColumnDimension($column)->setAutoSize(true);
+        }
+
+        $spreadsheet->setActiveSheetIndex(0);
+
+        return $spreadsheet;
+    }
+
+    private function buildQuizWorkbook(Quiz $quiz): Spreadsheet
+    {
+        $spreadsheet = new Spreadsheet();
+
+        $questions = $spreadsheet->getActiveSheet();
+        $questions->setTitle('Questions');
+
+        $this->quizSpreadsheetService->fillQuestionsSheet($questions, $quiz);
+
+        $results = $spreadsheet->createSheet();
+        $results->setTitle('Results');
+        $this->fillResultsSheet($results, $quiz);
+
+        $eliminations = $spreadsheet->createSheet();
+        $eliminations->setTitle('Eliminations');
+        $this->fillEliminationsSheet($eliminations, $quiz);
+
+        $spreadsheet->setActiveSheetIndex(0);
+
+        return $spreadsheet;
+    }
+
+    private function fillResultsSheet(Worksheet $sheet, Quiz $quiz): void
+    {
+        $sheet->fromArray(['Candidate', 'Correct answers', 'Corrections', 'Penalty (s)', 'Score', 'Time', 'Started', 'Active', 'Deleted'], null, 'A1');
+        $sheet->getStyle('1:1')->getFont()->setBold(true);
+
+        /** @var array<string, Result> $scoresByCandidateId */
+        $scoresByCandidateId = [];
+        foreach ($this->quizRepository->getScores($quiz) as $result) {
+            $scoresByCandidateId[$result->id->toString()] = $result;
+        }
+
+        $row = 2;
+        foreach ($quiz->candidateData as $quizCandidate) {
+            $candidate = $quizCandidate->candidate;
+            $result = $scoresByCandidateId[$candidate->id->toString()] ?? null;
+
+            $sheet->fromArray([
+                $candidate->name,
+                $result?->correct,
+                $result?->corrections,
+                $result?->penaltySeconds,
+                $result?->score,
+                $result instanceof Result ? $result->time->format('%i:%S') : null,
+                $quizCandidate->started?->format(\DateTimeInterface::ATOM),
+                $quizCandidate->active ? 'Yes' : 'No',
+                $quizCandidate->getDeletedAt()?->format(\DateTimeInterface::ATOM) ?? '',
+            ], null, 'A'.$row);
+            ++$row;
+        }
+
+        foreach (range('A', 'I') as $column) {
+            $sheet->getColumnDimension($column)->setAutoSize(true);
+        }
+    }
+
+    private function fillEliminationsSheet(Worksheet $sheet, Quiz $quiz): void
+    {
+        /** @var list<Candidate> $candidates */
+        $candidates = $quiz->season->candidates->toArray();
+
+        $header = ['Prepared at', 'Deleted'];
+        foreach ($candidates as $candidate) {
+            $header[] = $candidate->name;
+        }
+
+        $sheet->fromArray($header, null, 'A1');
+        $sheet->getStyle('1:1')->getFont()->setBold(true);
+
+        $row = 2;
+        foreach ($quiz->eliminations as $elimination) {
+            $line = [
+                $elimination->getCreatedAt()?->format(\DateTimeInterface::ATOM) ?? '',
+                $elimination->getDeletedAt()?->format(\DateTimeInterface::ATOM) ?? '',
+            ];
+
+            foreach ($candidates as $candidate) {
+                $line[] = $elimination->getScreenColour($candidate->name) ?? '';
+            }
+
+            $sheet->fromArray($line, null, 'A'.$row);
+            ++$row;
+        }
+
+        foreach (range('A', Coordinate::stringFromColumnIndex(2 + \count($candidates))) as $column) {
+            $sheet->getColumnDimension($column)->setAutoSize(true);
+        }
+    }
+
+    private function buildCandidatesWorkbook(Season $season): Spreadsheet
+    {
+        $spreadsheet = new Spreadsheet();
+
+        $candidatesSheet = $spreadsheet->getActiveSheet();
+        $candidatesSheet->setTitle('Candidates');
+        $candidatesSheet->fromArray(['Name', 'Public link identifier'], null, 'A1');
+        $candidatesSheet->getStyle('1:1')->getFont()->setBold(true);
+
+        $row = 2;
+        foreach ($season->candidates as $candidate) {
+            $candidatesSheet->fromArray([$candidate->name, $candidate->nameHash], null, 'A'.$row);
+            ++$row;
+        }
+
+        $candidatesSheet->getColumnDimension('A')->setAutoSize(true);
+        $candidatesSheet->getColumnDimension('B')->setAutoSize(true);
+
+        $infoSheet = $spreadsheet->createSheet();
+        $infoSheet->setTitle('Season info');
+        $infoSheet->getStyle('A:A')->getFont()->setBold(true);
+        $infoSheet->fromArray([
+            ['Season name', $season->name],
+            ['Season code', $season->seasonCode],
+            ['Number of quizzes', $season->quizzes->count()],
+            ['Number of candidates', $season->candidates->count()],
+            ['Active quiz', $season->activeQuiz instanceof Quiz ? $season->activeQuiz->name : ''],
+            ['Show numbers', $season->settings?->showNumbers ? 'Yes' : 'No'],
+            ['Confirm answers', $season->settings?->confirmAnswers ? 'Yes' : 'No'],
+            ['Shared with other owners', $season->owners->count() > 1 ? 'Yes' : 'No'],
+        ], null, 'A1');
+        $infoSheet->getColumnDimension('A')->setAutoSize(true);
+        $infoSheet->getColumnDimension('B')->setAutoSize(true);
+
+        $spreadsheet->setActiveSheetIndex(0);
+
+        return $spreadsheet;
+    }
+
+    /** @throws FilesystemException */
+    private function writeToTempFile(Spreadsheet $spreadsheet): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'tvdt_export_sheet_');
+        new Writer\Xlsx($spreadsheet)->save($path);
+
+        return $path;
+    }
+
+    /** Strips characters that are unsafe in a zip entry name or a downloaded filename (path separators, traversal, control characters). */
+    public static function sanitizeForPath(string $value): string
+    {
+        $sanitized = preg_replace('#[\\\\/:*?"<>|\x00-\x1F]+#', '-', $value);
+        $sanitized = mb_trim($sanitized, " .\t\n\r\0\x0B-");
+
+        return '' === $sanitized ? 'unnamed' : $sanitized;
+    }
+}

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -285,17 +285,16 @@ class DataExportService
 
         $candidatesSheet = $spreadsheet->getActiveSheet();
         $candidatesSheet->setTitle('Candidates');
-        $candidatesSheet->fromArray(['Name', 'Public link identifier'], null, 'A1');
+        $candidatesSheet->fromArray(['Name'], null, 'A1');
         $candidatesSheet->getStyle('1:1')->getFont()->setBold(true);
 
         $row = 2;
         foreach ($season->candidates as $candidate) {
-            $candidatesSheet->fromArray([$candidate->name, $candidate->nameHash], null, 'A'.$row);
+            $candidatesSheet->fromArray([$candidate->name], null, 'A'.$row);
             ++$row;
         }
 
         $candidatesSheet->getColumnDimension('A')->setAutoSize(true);
-        $candidatesSheet->getColumnDimension('B')->setAutoSize(true);
 
         $infoSheet = $spreadsheet->createSheet();
         $infoSheet->setTitle('Season info');

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -11,7 +11,9 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer;
 use Safe\Exceptions\FilesystemException;
 use Tvdt\Dto\Result;
+use Tvdt\Entity\BankQuestionUsage;
 use Tvdt\Entity\Candidate;
+use Tvdt\Entity\QuestionLabel;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
@@ -68,6 +70,10 @@ class DataExportService
                 $candidatesPath = $this->writeToTempFile($this->buildCandidatesWorkbook($season));
                 $tempXlsxFiles[] = $candidatesPath;
                 $zip->addFile($candidatesPath, $folder.'candidates.xlsx');
+
+                $questionBankPath = $this->writeToTempFile($this->buildQuestionBankWorkbook($season));
+                $tempXlsxFiles[] = $questionBankPath;
+                $zip->addFile($questionBankPath, $folder.'question-bank.xlsx');
             }
 
             $zip->close();
@@ -249,6 +255,92 @@ class DataExportService
         $spreadsheet->setActiveSheetIndex(0);
 
         return $spreadsheet;
+    }
+
+    private function buildQuestionBankWorkbook(Season $season): Spreadsheet
+    {
+        $spreadsheet = new Spreadsheet();
+
+        $questions = $spreadsheet->getActiveSheet();
+        $questions->setTitle('Questions');
+        $this->fillBankQuestionsSheet($questions, $season);
+
+        $labels = $spreadsheet->createSheet();
+        $labels->setTitle('Labels');
+        $this->fillQuestionLabelsSheet($labels, $season);
+
+        $spreadsheet->setActiveSheetIndex(0);
+
+        return $spreadsheet;
+    }
+
+    private function fillBankQuestionsSheet(Worksheet $sheet, Season $season): void
+    {
+        $metaColumns = ['Question', 'Reusable', 'Complete for quiz', 'Labels', 'Used in quizzes'];
+        $sheet->fromArray($metaColumns, null, 'A1');
+        $sheet->getStyle('1:1')->getFont()->setBold(true);
+
+        $answerStartColumnIndex = \count($metaColumns);
+        $maxAnswers = 0;
+        $row = 2;
+
+        foreach ($season->bankQuestions as $bankQuestion) {
+            $labels = implode(', ', array_map(
+                static fn (QuestionLabel $label): string => $label->name,
+                $bankQuestion->labels->toArray(),
+            ));
+            $usedInQuizzes = implode(', ', array_map(
+                static fn (BankQuestionUsage $usage): string => $usage->quiz->name,
+                $bankQuestion->usages->toArray(),
+            ));
+
+            $sheet->fromArray([
+                $bankQuestion->question,
+                $bankQuestion->reusable ? 'Yes' : 'No',
+                $bankQuestion->isCompleteForQuiz ? 'Yes' : 'No',
+                $labels,
+                $usedInQuizzes,
+            ], null, 'A'.$row);
+
+            $col = 0;
+            foreach ($bankQuestion->answers as $answer) {
+                $sheet->setCellValue(Coordinate::stringFromColumnIndex($answerStartColumnIndex + 1 + 2 * $col).$row, $answer->text);
+                $sheet->setCellValue(Coordinate::stringFromColumnIndex($answerStartColumnIndex + 2 + 2 * $col).$row, $answer->isRightAnswer);
+                ++$col;
+            }
+
+            $maxAnswers = max($maxAnswers, $col);
+            ++$row;
+        }
+
+        for ($i = 0; $i < $maxAnswers; ++$i) {
+            $answerCol = Coordinate::stringFromColumnIndex($answerStartColumnIndex + 1 + 2 * $i);
+            $correctCol = Coordinate::stringFromColumnIndex($answerStartColumnIndex + 2 + 2 * $i);
+
+            $sheet->setCellValue($answerCol.'1', 'Answer '.($i + 1));
+            $sheet->setCellValue($correctCol.'1', 'Correct');
+        }
+
+        $lastColumnIndex = $answerStartColumnIndex + max(1, 2 * $maxAnswers);
+        foreach (range('A', Coordinate::stringFromColumnIndex($lastColumnIndex)) as $column) {
+            $sheet->getColumnDimension($column)->setAutoSize(true);
+        }
+    }
+
+    private function fillQuestionLabelsSheet(Worksheet $sheet, Season $season): void
+    {
+        $sheet->fromArray(['Name', 'Colour', 'Slug'], null, 'A1');
+        $sheet->getStyle('1:1')->getFont()->setBold(true);
+
+        $row = 2;
+        foreach ($season->questionLabels as $label) {
+            $sheet->fromArray([$label->name, $label->colour->name, $label->slug], null, 'A'.$row);
+            ++$row;
+        }
+
+        foreach (['A', 'B', 'C'] as $column) {
+            $sheet->getColumnDimension($column)->setAutoSize(true);
+        }
     }
 
     /** @throws FilesystemException */

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -13,6 +13,7 @@ use Safe\Exceptions\FilesystemException;
 use Tvdt\Dto\Result;
 use Tvdt\Entity\BankQuestionUsage;
 use Tvdt\Entity\Candidate;
+use Tvdt\Entity\Question;
 use Tvdt\Entity\QuestionLabel;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
@@ -137,6 +138,10 @@ class DataExportService
 
         $this->quizSpreadsheetService->fillQuestionsSheet($questions, $quiz);
 
+        $rawAnswers = $spreadsheet->createSheet();
+        $rawAnswers->setTitle('Raw answers');
+        $this->fillRawAnswersSheet($rawAnswers, $quiz);
+
         $results = $spreadsheet->createSheet();
         $results->setTitle('Results');
         $this->fillResultsSheet($results, $quiz);
@@ -182,6 +187,52 @@ class DataExportService
 
         foreach (range('A', 'I') as $column) {
             $sheet->getColumnDimension($column)->setAutoSize(true);
+        }
+    }
+
+    /** Raw crosstab: one row per candidate, one column per question, cell = the answer text they gave. */
+    private function fillRawAnswersSheet(Worksheet $sheet, Quiz $quiz): void
+    {
+        /** @var list<Question> $questions */
+        $questions = $quiz->questions->toArray();
+
+        $header = ['Candidate'];
+        foreach ($questions as $question) {
+            $header[] = $question->question;
+        }
+
+        $sheet->fromArray($header, null, 'A1');
+        $sheet->getStyle('1:1')->getFont()->setBold(true);
+        $sheet->getStyle('1:1')->getAlignment()->setWrapText(true);
+
+        /** @var array<string, array<string, string>> $answersByCandidateAndQuestion */
+        $answersByCandidateAndQuestion = [];
+        foreach ($questions as $question) {
+            foreach ($question->answers as $answer) {
+                foreach ($answer->givenAnswers as $givenAnswer) {
+                    $candidateId = $givenAnswer->candidate->id->toString();
+                    $answersByCandidateAndQuestion[$candidateId][$question->id->toString()] = $answer->text;
+                }
+            }
+        }
+
+        $row = 2;
+        foreach ($quiz->candidateData as $quizCandidate) {
+            $candidate = $quizCandidate->candidate;
+
+            $line = [$candidate->name];
+            foreach ($questions as $question) {
+                $line[] = $answersByCandidateAndQuestion[$candidate->id->toString()][$question->id->toString()] ?? '';
+            }
+
+            $sheet->fromArray($line, null, 'A'.$row);
+            ++$row;
+        }
+
+        $lastColumnIndex = 1 + \count($questions);
+        foreach (range('A', Coordinate::stringFromColumnIndex($lastColumnIndex)) as $column) {
+            $sheet->getColumnDimension($column)->setWidth(30);
+            $sheet->getStyle($column.':'.$column)->getAlignment()->setWrapText(true);
         }
     }
 

--- a/src/Service/QuizSpreadsheetService.php
+++ b/src/Service/QuizSpreadsheetService.php
@@ -7,6 +7,7 @@ namespace Tvdt\Service;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Reader;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer;
 use Symfony\Component\HttpFoundation\File\File;
 use Tvdt\Entity\Answer;
@@ -117,8 +118,13 @@ class QuizSpreadsheetService
     public function quizToXlsx(Quiz $quiz): \Closure
     {
         $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        $this->fillQuestionsSheet($spreadsheet->getActiveSheet(), $quiz);
 
+        return $this->toXlsx($spreadsheet);
+    }
+
+    public function fillQuestionsSheet(Worksheet $sheet, Quiz $quiz): void
+    {
         // Write data rows first so we know the maximum answer count.
         $maxAnswers = 0;
         $row = 2;
@@ -153,11 +159,9 @@ class QuizSpreadsheetService
             $sheet->setCellValue($correctCol.'1', 'Correct');
             $sheet->getColumnDimension($correctCol)->setAutoSize(true);
         }
-
-        return $this->toXlsx($spreadsheet);
     }
 
-    private function toXlsx(Spreadsheet $spreadsheet): \Closure
+    public function toXlsx(Spreadsheet $spreadsheet): \Closure
     {
         $writer = new Writer\Xlsx($spreadsheet);
 

--- a/templates/backoffice/settings/index.html.twig
+++ b/templates/backoffice/settings/index.html.twig
@@ -58,7 +58,7 @@
             <section class="mb-5">
                 <h4>{{ 'Your data'|trans }}</h4>
                 <p>{{ 'Download an archive of everything stored under your account: your profile, the seasons you own, their quizzes, results and candidates.'|trans }}</p>
-                <a class="btn btn-secondary" href="{{ path('tvdt_backoffice_settings_download_data') }}">{{ 'Download data'|trans }}</a>
+                <a class="btn btn-primary" href="{{ path('tvdt_backoffice_settings_download_data') }}">{{ 'Download data'|trans }}</a>
             </section>
 
             <section class="mb-5">

--- a/templates/backoffice/settings/index.html.twig
+++ b/templates/backoffice/settings/index.html.twig
@@ -58,6 +58,9 @@
             <section class="mb-5">
                 <h4>{{ 'Your data'|trans }}</h4>
                 <p>{{ 'Download an archive of everything stored under your account: your profile, the seasons you own, their quizzes, results and candidates.'|trans }}</p>
+                {% if not app.user.isVerified %}
+                    <p class="text-warning">{{ 'Confirm your email address to enable this feature.'|trans }}</p>
+                {% endif %}
                 <a class="btn btn-primary" href="{{ path('tvdt_backoffice_settings_download_data') }}">{{ 'Download data'|trans }}</a>
             </section>
 

--- a/templates/backoffice/settings/index.html.twig
+++ b/templates/backoffice/settings/index.html.twig
@@ -55,14 +55,10 @@
                 {{ form(emailForm, {action: path('tvdt_backoffice_settings_email')}) }}
             </section>
 
-            <section class="mb-5" data-controller="bo--popover">
+            <section class="mb-5">
                 <h4>{{ 'Your data'|trans }}</h4>
-                <span class="d-inline-block" tabindex="0"
-                      data-bs-toggle="popover"
-                      data-bs-trigger="hover focus"
-                      data-bs-content="{{ 'Soon™'|trans }}">
-                    <button type="button" class="btn btn-secondary pe-none" disabled>{{ 'Download data'|trans }}</button>
-                </span>
+                <p>{{ 'Download an archive of everything stored under your account: your profile, the seasons you own, their quizzes, results and candidates.'|trans }}</p>
+                <a class="btn btn-secondary" href="{{ path('tvdt_backoffice_settings_download_data') }}">{{ 'Download data'|trans }}</a>
             </section>
 
             <section class="mb-5">

--- a/tests/Controller/Backoffice/BackofficeControllerTest.php
+++ b/tests/Controller/Backoffice/BackofficeControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Controller\Backoffice;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Tvdt\Controller\Backoffice\BackofficeController;
+use Tvdt\Entity\Quiz;
+use Tvdt\Entity\User;
+
+#[CoversClass(BackofficeController::class)]
+final class BackofficeControllerTest extends WebTestCase
+{
+    public function testExportQuizFilenameIsSanitized(): void
+    {
+        $client = self::createClient();
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy(['email' => 'user2@example.org']);
+        $this->assertInstanceOf(User::class, $user);
+        $client->loginUser($user);
+
+        $quiz = $entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Quiz 1']);
+        $this->assertInstanceOf(Quiz::class, $quiz);
+
+        $client->request(Request::METHOD_GET, \sprintf('/backoffice/quiz/%s/export', $quiz->id));
+
+        self::assertResponseIsSuccessful();
+        $disposition = (string) $client->getResponse()->headers->get('Content-Disposition');
+        $this->assertStringContainsString('filename=Quiz-1.xlsx', $disposition);
+        $this->assertStringNotContainsString('Quiz 1.xlsx', $disposition);
+    }
+}

--- a/tests/Controller/Backoffice/BackofficeControllerTest.php
+++ b/tests/Controller/Backoffice/BackofficeControllerTest.php
@@ -22,6 +22,8 @@ final class BackofficeControllerTest extends WebTestCase
 
         $user = $entityManager->getRepository(User::class)->findOneBy(['email' => 'user2@example.org']);
         $this->assertInstanceOf(User::class, $user);
+        $user->isVerified = true;
+        $entityManager->flush();
         $client->loginUser($user);
 
         $quiz = $entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Quiz 1']);
@@ -33,5 +35,23 @@ final class BackofficeControllerTest extends WebTestCase
         $disposition = (string) $client->getResponse()->headers->get('Content-Disposition');
         $this->assertStringContainsString('filename=Quiz-1.xlsx', $disposition);
         $this->assertStringNotContainsString('Quiz 1.xlsx', $disposition);
+    }
+
+    public function testExportQuizRequiresVerifiedEmail(): void
+    {
+        $client = self::createClient();
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy(['email' => 'user2@example.org']);
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertFalse($user->isVerified);
+        $client->loginUser($user);
+
+        $quiz = $entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Quiz 1']);
+        $this->assertInstanceOf(Quiz::class, $quiz);
+
+        $client->request(Request::METHOD_GET, \sprintf('/backoffice/quiz/%s/export', $quiz->id));
+
+        self::assertResponseRedirects(\sprintf('/backoffice/season/%s', $quiz->season->seasonCode));
     }
 }

--- a/tests/Controller/Backoffice/SettingsControllerTest.php
+++ b/tests/Controller/Backoffice/SettingsControllerTest.php
@@ -368,7 +368,7 @@ final class SettingsControllerTest extends WebTestCase
 
         $disposition = (string) $this->client->getResponse()->headers->get('Content-Disposition');
         $this->assertMatchesRegularExpression(
-            '/filename="tijd-voor-de-test-data-test@example\.org-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.zip"/',
+            '/filename=tijd-voor-de-test-data-test-example-org-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.zip/',
             $disposition,
         );
     }

--- a/tests/Controller/Backoffice/SettingsControllerTest.php
+++ b/tests/Controller/Backoffice/SettingsControllerTest.php
@@ -361,6 +361,8 @@ final class SettingsControllerTest extends WebTestCase
 
     public function testDownloadDataReturnsAZipWithATimestampedAccountFilename(): void
     {
+        $this->markUserVerified('test@example.org');
+
         $this->client->request(Request::METHOD_GET, '/backoffice/settings/download-data');
 
         self::assertResponseIsSuccessful();
@@ -371,5 +373,24 @@ final class SettingsControllerTest extends WebTestCase
             '/filename=tijd-voor-de-test-data-test-example-org-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.zip/',
             $disposition,
         );
+    }
+
+    public function testDownloadDataRequiresVerifiedEmail(): void
+    {
+        $user = $this->getUserByEmail('test@example.org');
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertFalse($user->isVerified);
+
+        $this->client->request(Request::METHOD_GET, '/backoffice/settings/download-data');
+
+        self::assertResponseRedirects('/backoffice/settings');
+    }
+
+    private function markUserVerified(string $email): void
+    {
+        $user = $this->getUserByEmail($email);
+        $this->assertInstanceOf(User::class, $user);
+        $user->isVerified = true;
+        $this->entityManager->flush();
     }
 }

--- a/tests/Controller/Backoffice/SettingsControllerTest.php
+++ b/tests/Controller/Backoffice/SettingsControllerTest.php
@@ -350,4 +350,26 @@ final class SettingsControllerTest extends WebTestCase
             $this->assertNotEmpty($ownerEmails);
         }
     }
+
+    public function testDownloadDataRequiresAuthentication(): void
+    {
+        $this->client->restart();
+        $this->client->request(Request::METHOD_GET, '/backoffice/settings/download-data');
+
+        self::assertResponseRedirects();
+    }
+
+    public function testDownloadDataReturnsAZipWithATimestampedAccountFilename(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/backoffice/settings/download-data');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('Content-Type', 'application/zip');
+
+        $disposition = (string) $this->client->getResponse()->headers->get('Content-Disposition');
+        $this->assertMatchesRegularExpression(
+            '/filename="tijd-voor-de-test-data-test@example\.org-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.zip"/',
+            $disposition,
+        );
+    }
 }

--- a/tests/Helpers/FilenameSanitizerTest.php
+++ b/tests/Helpers/FilenameSanitizerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use Tvdt\Helpers\FilenameSanitizer;
+
+final class FilenameSanitizerTest extends TestCase
+{
+    public function testReplacesSpacesWithDashes(): void
+    {
+        $this->assertSame('Krtek-Weekend', FilenameSanitizer::sanitize('Krtek Weekend'));
+    }
+
+    public function testStripsPathSeparatorsAndTraversal(): void
+    {
+        $this->assertSame('etc-passwd', FilenameSanitizer::sanitize('../../etc/passwd'));
+        $this->assertSame('a-b', FilenameSanitizer::sanitize('a/b'));
+        $this->assertSame('a-b', FilenameSanitizer::sanitize('a\\b'));
+    }
+
+    public function testStripsControlCharactersAndSpecialSymbols(): void
+    {
+        $this->assertSame('Quiz-1-script', FilenameSanitizer::sanitize("Quiz #1 <script>\0"));
+    }
+
+    public function testTransliteratesUnicodeToAscii(): void
+    {
+        $this->assertSame('Weird-Name', FilenameSanitizer::sanitize('Wéird Ñame'));
+    }
+
+    public function testTransliteratesAtSignInEmail(): void
+    {
+        $this->assertSame('test-example-org', FilenameSanitizer::sanitize('test@example.org'));
+    }
+
+    public function testReturnsUnnamedForEmptyOrFullyStrippedInput(): void
+    {
+        $this->assertSame('unnamed', FilenameSanitizer::sanitize(''));
+        $this->assertSame('unnamed', FilenameSanitizer::sanitize('///'));
+    }
+}

--- a/tests/Repository/UserRepositoryTest.php
+++ b/tests/Repository/UserRepositoryTest.php
@@ -7,6 +7,12 @@ namespace Tvdt\Tests\Repository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Tvdt\DataFixtures\TestFixtures;
+use Tvdt\Entity\BankQuestion;
+use Tvdt\Entity\Elimination;
+use Tvdt\Entity\GivenAnswer;
+use Tvdt\Entity\Question;
+use Tvdt\Entity\Quiz;
+use Tvdt\Entity\QuizCandidate;
 use Tvdt\Repository\UserRepository;
 
 use function PHPUnit\Framework\assertEmpty;
@@ -41,5 +47,90 @@ final class UserRepositoryTest extends DatabaseTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->userRepository->makeAdmin('invalid@example.org');
+    }
+
+    /**
+     * GDPR right-to-erasure: deleting the sole owner of a season must physically remove every
+     * row tied to it, not merely soft-delete it. QuizCandidate, GivenAnswer, and Elimination are
+     * all Gedmo\SoftDeleteable, so a naive $em->remove($season) cascade leaves them (or the
+     * transaction itself) behind. Assertions bypass the softdeleteable filter and read raw SQL,
+     * since a soft-deleted row would otherwise still be invisible to a filtered ORM query.
+     */
+    public function testDeleteUserHardDeletesQuizCandidateGivenAnswerAndElimination(): void
+    {
+        $user = $this->getUserByEmail('sole-owner@example.org');
+        $season = $this->getSeasonByCode('doomd');
+
+        $quiz = $this->entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Doomed Quiz', 'season' => $season]);
+        $this->assertInstanceOf(Quiz::class, $quiz);
+        $candidate = $this->getCandidateBySeasonAndName($season, 'Vera');
+
+        /** @var Question $question */
+        $question = $quiz->questions->first();
+        $rightAnswer = $question->answers->first();
+        $this->assertNotFalse($rightAnswer);
+
+        $this->quizCandidateRepository->createIfNotExist($quiz, $candidate);
+        $quizCandidate = $this->quizCandidateRepository->findOneBy(['quiz' => $quiz, 'candidate' => $candidate]);
+        $this->assertInstanceOf(QuizCandidate::class, $quizCandidate);
+
+        $givenAnswer = new GivenAnswer($candidate, $quiz, $rightAnswer);
+        $this->entityManager->persist($givenAnswer);
+
+        $elimination = new Elimination($quiz);
+        $elimination->data = ['Vera' => Elimination::SCREEN_GREEN];
+
+        $this->entityManager->persist($elimination);
+
+        $this->entityManager->flush();
+
+        $quizCandidateId = $quizCandidate->id->toString();
+        $givenAnswerId = $givenAnswer->id->toString();
+        $eliminationId = $elimination->id->toString();
+
+        $this->userRepository->deleteUser($user);
+        $this->entityManager->clear();
+
+        $connection = $this->entityManager->getConnection();
+        $this->assertSame(0, (int) $connection->fetchOne('select count(*) from quiz_candidate where id = ?', [$quizCandidateId]));
+        $this->assertSame(0, (int) $connection->fetchOne('select count(*) from given_answer where id = ?', [$givenAnswerId]));
+        $this->assertSame(0, (int) $connection->fetchOne('select count(*) from elimination where id = ?', [$eliminationId]));
+    }
+
+    /**
+     * Gedmo\Loggable writes an audit row (including the editor's username/email) to
+     * ext_log_entries for every change to a Versioned field. Those rows aren't linked via a
+     * foreign key (object_id is a plain string), so deleting the season/BankQuestion never
+     * cleans them up on its own — the deleted account's email would otherwise live on forever.
+     */
+    public function testDeleteUserPurgesBankQuestionAuditLogEntries(): void
+    {
+        $user = $this->getUserByEmail('sole-owner@example.org');
+        $season = $this->getSeasonByCode('doomd');
+
+        $bankQuestion = new BankQuestion();
+        $bankQuestion->question = 'Wie is de Krtek eigenlijk?';
+        $bankQuestion->season = $season;
+
+        $this->entityManager->persist($bankQuestion);
+        $this->entityManager->flush();
+
+        $bankQuestionId = $bankQuestion->id->toString();
+        $connection = $this->entityManager->getConnection();
+
+        $logCountBefore = (int) $connection->fetchOne(
+            'select count(*) from ext_log_entries where object_class = ? and object_id = ?',
+            [BankQuestion::class, $bankQuestionId],
+        );
+        $this->assertGreaterThan(0, $logCountBefore);
+
+        $this->userRepository->deleteUser($user);
+        $this->entityManager->clear();
+
+        $logCountAfter = (int) $connection->fetchOne(
+            'select count(*) from ext_log_entries where object_class = ? and object_id = ?',
+            [BankQuestion::class, $bankQuestionId],
+        );
+        $this->assertSame(0, $logCountAfter);
     }
 }

--- a/tests/Service/DataExportServiceTest.php
+++ b/tests/Service/DataExportServiceTest.php
@@ -61,27 +61,27 @@ final class DataExportServiceTest extends DatabaseTestCase
         $names = $this->entryNames($zip);
 
         $this->assertContains('profile.xlsx', $names);
-        $this->assertContains('krtek-Krtek Weekend/Quiz 1.xlsx', $names);
-        $this->assertContains('krtek-Krtek Weekend/Quiz 2.xlsx', $names);
-        $this->assertContains('krtek-Krtek Weekend/candidates.xlsx', $names);
-        $this->assertContains('krtek-Krtek Weekend/question-bank.xlsx', $names);
-        $this->assertContains('bbbbb-Another Season/candidates.xlsx', $names);
-        $this->assertContains('bbbbb-Another Season/question-bank.xlsx', $names);
+        $this->assertContains('krtek-Krtek-Weekend/Quiz-1.xlsx', $names);
+        $this->assertContains('krtek-Krtek-Weekend/Quiz-2.xlsx', $names);
+        $this->assertContains('krtek-Krtek-Weekend/candidates.xlsx', $names);
+        $this->assertContains('krtek-Krtek-Weekend/question-bank.xlsx', $names);
+        $this->assertContains('bbbbb-Another-Season/candidates.xlsx', $names);
+        $this->assertContains('bbbbb-Another-Season/question-bank.xlsx', $names);
 
         // Another Season has no quizzes, so no quiz xlsx should be present for it.
         foreach ($names as $name) {
-            $this->assertStringStartsNotWith('bbbbb-Another Season/Quiz', $name);
+            $this->assertStringStartsNotWith('bbbbb-Another-Season/Quiz', $name);
         }
 
-        $quizContent = $zip->getFromName('krtek-Krtek Weekend/Quiz 1.xlsx');
+        $quizContent = $zip->getFromName('krtek-Krtek-Weekend/Quiz-1.xlsx');
         $this->assertIsString($quizContent);
         $this->assertSame(['Questions', 'Raw answers', 'Results', 'Eliminations'], $this->sheetNames($quizContent));
 
-        $candidatesContent = $zip->getFromName('krtek-Krtek Weekend/candidates.xlsx');
+        $candidatesContent = $zip->getFromName('krtek-Krtek-Weekend/candidates.xlsx');
         $this->assertIsString($candidatesContent);
         $this->assertSame(['Candidates', 'Season info'], $this->sheetNames($candidatesContent));
 
-        $questionBankContent = $zip->getFromName('krtek-Krtek Weekend/question-bank.xlsx');
+        $questionBankContent = $zip->getFromName('krtek-Krtek-Weekend/question-bank.xlsx');
         $this->assertIsString($questionBankContent);
         $this->assertSame(['Questions', 'Labels'], $this->sheetNames($questionBankContent));
 
@@ -92,7 +92,7 @@ final class DataExportServiceTest extends DatabaseTestCase
     {
         $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
 
-        $questionBankContent = $zip->getFromName('krtek-Krtek Weekend/question-bank.xlsx');
+        $questionBankContent = $zip->getFromName('krtek-Krtek-Weekend/question-bank.xlsx');
         $this->assertIsString($questionBankContent);
         $zip->close();
 
@@ -151,7 +151,7 @@ final class DataExportServiceTest extends DatabaseTestCase
         $this->entityManager->clear();
 
         $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
-        $quizContent = $zip->getFromName('krtek-Krtek Weekend/Quiz 1.xlsx');
+        $quizContent = $zip->getFromName('krtek-Krtek-Weekend/Quiz-1.xlsx');
         $this->assertIsString($quizContent);
         $zip->close();
 
@@ -182,7 +182,7 @@ final class DataExportServiceTest extends DatabaseTestCase
         $this->entityManager->flush();
 
         $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
-        $quizContent = $zip->getFromName('krtek-Krtek Weekend/Quiz 1.xlsx');
+        $quizContent = $zip->getFromName('krtek-Krtek-Weekend/Quiz-1.xlsx');
         $this->assertIsString($quizContent);
         $zip->close();
 

--- a/tests/Service/DataExportServiceTest.php
+++ b/tests/Service/DataExportServiceTest.php
@@ -61,7 +61,9 @@ final class DataExportServiceTest extends DatabaseTestCase
         $this->assertContains('krtek-Krtek Weekend/Quiz 1.xlsx', $names);
         $this->assertContains('krtek-Krtek Weekend/Quiz 2.xlsx', $names);
         $this->assertContains('krtek-Krtek Weekend/candidates.xlsx', $names);
+        $this->assertContains('krtek-Krtek Weekend/question-bank.xlsx', $names);
         $this->assertContains('bbbbb-Another Season/candidates.xlsx', $names);
+        $this->assertContains('bbbbb-Another Season/question-bank.xlsx', $names);
 
         // Another Season has no quizzes, so no quiz xlsx should be present for it.
         foreach ($names as $name) {
@@ -76,7 +78,43 @@ final class DataExportServiceTest extends DatabaseTestCase
         $this->assertIsString($candidatesContent);
         $this->assertSame(['Candidates', 'Season info'], $this->sheetNames($candidatesContent));
 
+        $questionBankContent = $zip->getFromName('krtek-Krtek Weekend/question-bank.xlsx');
+        $this->assertIsString($questionBankContent);
+        $this->assertSame(['Questions', 'Labels'], $this->sheetNames($questionBankContent));
+
         $zip->close();
+    }
+
+    public function testQuestionBankSheetIncludesBankQuestionsAndUsage(): void
+    {
+        $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
+
+        $questionBankContent = $zip->getFromName('krtek-Krtek Weekend/question-bank.xlsx');
+        $this->assertIsString($questionBankContent);
+        $zip->close();
+
+        $rows = $this->loadSheet($questionBankContent, 'Questions')->toArray();
+        $header = $rows[0];
+        $dataRows = \array_slice($rows, 1);
+
+        $questionIndex = array_search('Question', $header, true);
+        $reusableIndex = array_search('Reusable', $header, true);
+        $labelsIndex = array_search('Labels', $header, true);
+        $usedInQuizzesIndex = array_search('Used in quizzes', $header, true);
+
+        $reusableRow = current(array_filter($dataRows, static fn (array $row): bool => 'Wie is de Krtek?' === $row[$questionIndex]));
+        $this->assertIsArray($reusableRow);
+        $this->assertSame('Yes', $reusableRow[$reusableIndex]);
+        $this->assertSame('Finale', $reusableRow[$labelsIndex]);
+
+        $usedRow = current(array_filter($dataRows, static fn (array $row): bool => 'Waar sliep de Krtek?' === $row[$questionIndex]));
+        $this->assertIsArray($usedRow);
+        $this->assertSame('Quiz 2', $usedRow[$usedInQuizzesIndex]);
+
+        $labelRows = $this->loadSheet($questionBankContent, 'Labels')->toArray();
+        $labelNames = array_column(\array_slice($labelRows, 1), 0);
+        $this->assertContains('Locatie', $labelNames);
+        $this->assertContains('Finale', $labelNames);
     }
 
     public function testProfileSheetDoesNotContainPasswordHash(): void

--- a/tests/Service/DataExportServiceTest.php
+++ b/tests/Service/DataExportServiceTest.php
@@ -7,6 +7,9 @@ namespace Tvdt\Tests\Service;
 use PhpOffice\PhpSpreadsheet\Reader;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\Attributes\CoversClass;
+use Tvdt\Entity\Answer;
+use Tvdt\Entity\GivenAnswer;
+use Tvdt\Entity\Question;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\QuizCandidate;
 use Tvdt\Entity\User;
@@ -72,7 +75,7 @@ final class DataExportServiceTest extends DatabaseTestCase
 
         $quizContent = $zip->getFromName('krtek-Krtek Weekend/Quiz 1.xlsx');
         $this->assertIsString($quizContent);
-        $this->assertSame(['Questions', 'Results', 'Eliminations'], $this->sheetNames($quizContent));
+        $this->assertSame(['Questions', 'Raw answers', 'Results', 'Eliminations'], $this->sheetNames($quizContent));
 
         $candidatesContent = $zip->getFromName('krtek-Krtek Weekend/candidates.xlsx');
         $this->assertIsString($candidatesContent);
@@ -158,6 +161,44 @@ final class DataExportServiceTest extends DatabaseTestCase
         $hasDeletedRow = array_any(\array_slice($rows, 1), static fn (array $row): bool => null !== $row[$deletedColumnIndex] && '' !== $row[$deletedColumnIndex]);
 
         $this->assertTrue($hasDeletedRow, 'Expected the soft-deleted QuizCandidate to still appear with a Deleted timestamp');
+    }
+
+    public function testRawAnswersSheetShowsCandidatesByQuestionsGrid(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $quiz = $this->entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Quiz 1', 'season' => $season]);
+        $this->assertInstanceOf(Quiz::class, $quiz);
+        $candidate = $this->getCandidateBySeasonAndName($season, 'Claudia');
+
+        /** @var Question $firstQuestion */
+        $firstQuestion = $quiz->questions->first();
+        $chosenAnswer = $firstQuestion->answers->filter(static fn (Answer $answer): bool => 'Man' === $answer->text)->first();
+        $this->assertInstanceOf(Answer::class, $chosenAnswer);
+
+        $this->quizCandidateRepository->createIfNotExist($quiz, $candidate);
+
+        $givenAnswer = new GivenAnswer($candidate, $quiz, $chosenAnswer);
+        $this->entityManager->persist($givenAnswer);
+        $this->entityManager->flush();
+
+        $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
+        $quizContent = $zip->getFromName('krtek-Krtek Weekend/Quiz 1.xlsx');
+        $this->assertIsString($quizContent);
+        $zip->close();
+
+        $rows = $this->loadSheet($quizContent, 'Raw answers')->toArray();
+        $header = $rows[0];
+        $this->assertSame('Candidate', $header[0]);
+
+        $questionColumnIndex = array_search($firstQuestion->question, $header, true);
+        $this->assertIsInt($questionColumnIndex);
+
+        $claudiaRow = current(array_filter(
+            \array_slice($rows, 1),
+            static fn (array $row): bool => 'Claudia' === $row[0],
+        ));
+        $this->assertIsArray($claudiaRow);
+        $this->assertSame('Man', $claudiaRow[$questionColumnIndex]);
     }
 
     private function openZip(User $user): \ZipArchive

--- a/tests/Service/DataExportServiceTest.php
+++ b/tests/Service/DataExportServiceTest.php
@@ -75,7 +75,7 @@ final class DataExportServiceTest extends DatabaseTestCase
 
         $quizContent = $zip->getFromName('krtek-Krtek-Weekend/Quiz-1.xlsx');
         $this->assertIsString($quizContent);
-        $this->assertSame(['Questions', 'Raw answers', 'Results', 'Eliminations'], $this->sheetNames($quizContent));
+        $this->assertSame(['Quiz info', 'Questions', 'Raw answers', 'Results', 'Eliminations'], $this->sheetNames($quizContent));
 
         $candidatesContent = $zip->getFromName('krtek-Krtek-Weekend/candidates.xlsx');
         $this->assertIsString($candidatesContent);
@@ -199,6 +199,37 @@ final class DataExportServiceTest extends DatabaseTestCase
         ));
         $this->assertIsArray($claudiaRow);
         $this->assertSame('Man', $claudiaRow[$questionColumnIndex]);
+    }
+
+    public function testQuizInfoSheetShowsDropoutsFinalizationAndDisabledQuestions(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $quiz = $this->entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Quiz 1', 'season' => $season]);
+        $this->assertInstanceOf(Quiz::class, $quiz);
+        $this->assertTrue($quiz->isFinalized);
+
+        /** @var Question $disabledQuestion */
+        $disabledQuestion = $quiz->questions->first();
+        $disabledQuestion->enabled = false;
+
+        $this->entityManager->flush();
+
+        $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
+        $quizContent = $zip->getFromName('krtek-Krtek-Weekend/Quiz-1.xlsx');
+        $this->assertIsString($quizContent);
+        $zip->close();
+
+        $rows = $this->loadSheet($quizContent, 'Quiz info')->toArray();
+        $values = [];
+        foreach ($rows as $row) {
+            $values[$row[0]] = $row[1];
+        }
+
+        $this->assertSame('Quiz 1', $values['Quiz name']);
+        $this->assertSame($quiz->dropouts, (int) $values['Number of dropouts']);
+        $this->assertSame('Yes', $values['Finalized']);
+        $this->assertNotEmpty($values['Finalized at']);
+        $this->assertStringContainsString($disabledQuestion->question, (string) $values['Disabled questions']);
     }
 
     private function openZip(User $user): \ZipArchive

--- a/tests/Service/DataExportServiceTest.php
+++ b/tests/Service/DataExportServiceTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Service;
+
+use PhpOffice\PhpSpreadsheet\Reader;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tvdt\Entity\Quiz;
+use Tvdt\Entity\QuizCandidate;
+use Tvdt\Entity\User;
+use Tvdt\Service\DataExportService;
+use Tvdt\Tests\Repository\DatabaseTestCase;
+
+use function Safe\file_put_contents;
+use function Safe\tempnam;
+use function Safe\unlink;
+
+#[CoversClass(DataExportService::class)]
+final class DataExportServiceTest extends DatabaseTestCase
+{
+    private DataExportService $subject;
+
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = self::getContainer()->get(DataExportService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testExportForUserWithNoSeasonsContainsOnlyProfile(): void
+    {
+        $zip = $this->openZip($this->getUserByEmail('test@example.org'));
+
+        $this->assertSame(1, $zip->numFiles);
+        $this->assertNotFalse($zip->locateName('profile.xlsx'));
+        $zip->close();
+    }
+
+    public function testExportForUserIncludesOwnedSeasonsQuizzesAndCandidates(): void
+    {
+        $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
+
+        $names = $this->entryNames($zip);
+
+        $this->assertContains('profile.xlsx', $names);
+        $this->assertContains('krtek-Krtek Weekend/Quiz 1.xlsx', $names);
+        $this->assertContains('krtek-Krtek Weekend/Quiz 2.xlsx', $names);
+        $this->assertContains('krtek-Krtek Weekend/candidates.xlsx', $names);
+        $this->assertContains('bbbbb-Another Season/candidates.xlsx', $names);
+
+        // Another Season has no quizzes, so no quiz xlsx should be present for it.
+        foreach ($names as $name) {
+            $this->assertStringStartsNotWith('bbbbb-Another Season/Quiz', $name);
+        }
+
+        $quizContent = $zip->getFromName('krtek-Krtek Weekend/Quiz 1.xlsx');
+        $this->assertIsString($quizContent);
+        $this->assertSame(['Questions', 'Results', 'Eliminations'], $this->sheetNames($quizContent));
+
+        $candidatesContent = $zip->getFromName('krtek-Krtek Weekend/candidates.xlsx');
+        $this->assertIsString($candidatesContent);
+        $this->assertSame(['Candidates', 'Season info'], $this->sheetNames($candidatesContent));
+
+        $zip->close();
+    }
+
+    public function testProfileSheetDoesNotContainPasswordHash(): void
+    {
+        $user = $this->getUserByEmail('user2@example.org');
+        $zip = $this->openZip($user);
+
+        $profileContent = $zip->getFromName('profile.xlsx');
+        $this->assertIsString($profileContent);
+        $zip->close();
+
+        $rows = $this->loadSheet($profileContent, 'Account')->toArray();
+        $flattened = implode(' ', array_merge(...$rows));
+
+        $this->assertStringNotContainsString($user->password, $flattened);
+    }
+
+    public function testResultsSheetIncludesSoftDeletedQuizCandidates(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $quiz = $this->entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Quiz 1', 'season' => $season]);
+        $this->assertInstanceOf(Quiz::class, $quiz);
+        $candidate = $this->getCandidateBySeasonAndName($season, 'Claudia');
+
+        $quizCandidate = new QuizCandidate($quiz, $candidate);
+        $this->entityManager->persist($quizCandidate);
+        $this->entityManager->flush();
+
+        $this->entityManager->remove($quizCandidate);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
+        $quizContent = $zip->getFromName('krtek-Krtek Weekend/Quiz 1.xlsx');
+        $this->assertIsString($quizContent);
+        $zip->close();
+
+        $rows = $this->loadSheet($quizContent, 'Results')->toArray();
+        $deletedColumnIndex = array_search('Deleted', $rows[0], true);
+        $this->assertIsInt($deletedColumnIndex);
+        $hasDeletedRow = array_any(\array_slice($rows, 1), static fn (array $row): bool => null !== $row[$deletedColumnIndex] && '' !== $row[$deletedColumnIndex]);
+
+        $this->assertTrue($hasDeletedRow, 'Expected the soft-deleted QuizCandidate to still appear with a Deleted timestamp');
+    }
+
+    private function openZip(User $user): \ZipArchive
+    {
+        $zipPath = $this->subject->exportForUser($user);
+        $this->tempFiles[] = $zipPath;
+
+        $zip = new \ZipArchive();
+        $this->assertTrue($zip->open($zipPath));
+
+        return $zip;
+    }
+
+    /** @return list<string> */
+    private function entryNames(\ZipArchive $zip): array
+    {
+        $names = [];
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $name = $zip->getNameIndex($i);
+            $this->assertIsString($name);
+            $names[] = $name;
+        }
+
+        return $names;
+    }
+
+    /** @return list<string> */
+    private function sheetNames(string $xlsxContent): array
+    {
+        $path = $this->createTempPath();
+        file_put_contents($path, $xlsxContent);
+
+        return array_values(new Reader\Xlsx()->load($path)->getSheetNames());
+    }
+
+    private function loadSheet(string $xlsxContent, string $sheetName): Worksheet
+    {
+        $path = $this->createTempPath();
+        file_put_contents($path, $xlsxContent);
+
+        $sheet = new Reader\Xlsx()->load($path)->getSheetByName($sheetName);
+        $this->assertInstanceOf(Worksheet::class, $sheet);
+
+        return $sheet;
+    }
+
+    private function createTempPath(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'tvdt_export_test_');
+        $this->tempFiles[] = $path;
+
+        return $path;
+    }
+}

--- a/translations/messages+intl-icu.nl.xliff
+++ b/translations/messages+intl-icu.nl.xliff
@@ -293,6 +293,10 @@
         <source>Download Template</source>
         <target>Download sjabloon</target>
       </trans-unit>
+      <trans-unit id="43g0Dc8" resname="Download an archive of everything stored under your account: your profile, the seasons you own, their quizzes, results and candidates.">
+        <source>Download an archive of everything stored under your account: your profile, the seasons you own, their quizzes, results and candidates.</source>
+        <target>Download een archief met alles wat onder je account is opgeslagen: je profiel, de seizoenen die je bezit, met de bijbehorende testen, resultaten en kandidaten.</target>
+      </trans-unit>
       <trans-unit id="58e2QWG" resname="Download data">
         <source>Download data</source>
         <target>Gegevens downloaden</target>

--- a/translations/messages+intl-icu.nl.xliff
+++ b/translations/messages+intl-icu.nl.xliff
@@ -205,6 +205,14 @@
         <source>Confirm Answers</source>
         <target>Bevestig antwoorden</target>
       </trans-unit>
+      <trans-unit id="T1Z6nI1" resname="Confirm your email address to enable this feature.">
+        <source>Confirm your email address to enable this feature.</source>
+        <target>Bevestig je e-mailadres om deze functie te kunnen gebruiken.</target>
+      </trans-unit>
+      <trans-unit id="QZfvKMx" resname="Confirm your email address to enable this.">
+        <source>Confirm your email address to enable this.</source>
+        <target>Bevestig je e-mailadres om dit te gebruiken.</target>
+      </trans-unit>
       <trans-unit id="PiAVEe9" resname="Confirmed">
         <source>Confirmed</source>
         <target>Bevestigd</target>
@@ -560,6 +568,18 @@
       <trans-unit id="6EclFME" resname="Please Confirm your Email">
         <source>Please Confirm your Email</source>
         <target>Bevestig je e-mailadres alsjeblieft</target>
+      </trans-unit>
+      <trans-unit id="7osID7L" resname="Please confirm your email address before downloading your data.">
+        <source>Please confirm your email address before downloading your data.</source>
+        <target>Bevestig eerst je e-mailadres voordat je je gegevens downloadt.</target>
+      </trans-unit>
+      <trans-unit id="XS4opCD" resname="Please confirm your email address before exporting a quiz.">
+        <source>Please confirm your email address before exporting a quiz.</source>
+        <target>Bevestig je e-mailadres voordat je een quiz exporteert.</target>
+      </trans-unit>
+      <trans-unit id="y4TgBCP" resname="Please confirm your email address before exporting data.">
+        <source>Please confirm your email address before exporting data.</source>
+        <target>Bevestig eerst je e-mailadres voordat je gegevens exporteert.</target>
       </trans-unit>
       <trans-unit id="mq1QYAv" resname="Please select an answer">
         <source>Please select an answer</source>


### PR DESCRIPTION
## Summary
- Wires up the previously disabled "Download data" button (blue/`btn-primary`) on the personal Settings page. It now downloads a zip named `tijd-voor-de-test-data-{email-slug}-{timestamp}.zip` containing:
  - `profile.xlsx` (root) — Account tab (email, roles, verified status, ID — no password hash) + Seasons tab (name, code, quiz/candidate counts, shared-with-others flag)
  - Per owned season, folder `{seasonCode}-{seasonName-slug}/` with:
    - One `{quizName-slug}.xlsx` per quiz (**Quiz info** / Questions / Raw answers / Results / Eliminations tabs)
      - **Quiz info**: number of dropouts, finalized status + timestamp, disabled questions
      - **Raw answers**: a crosstab — one row per candidate, one column per question, with the exact answer text they gave
      - Results: aggregated scores (correct count, corrections, penalty, score, time, started/active/deleted status)
    - `candidates.xlsx` (Candidates / Season info tabs)
    - `question-bank.xlsx` (Questions tab — bank questions, answers, reusable/complete flags, labels, and which quizzes they've been used in; Labels tab)
- Scoped to seasons the logged-in user owns (including admins). Soft-deleted `QuizCandidate`/`GivenAnswer`/`Elimination` rows are included and flagged with a `Deleted` timestamp.

### Antispam: exports require a confirmed email
Both the full data export and the existing single-quiz export (`BackofficeController::exportQuiz`) now redirect with a flash warning instead of exporting when the account's email isn't verified. A matching hint appears next to the download button on the settings page.

### Completeness audit (export vs. delete)
Ran two parallel audits checking every entity field against both flows. **Delete: fully covered**, no changes needed (verified every cascade/orphanRemoval/onDelete relation, all three `Gedmo\SoftDeleteable` entities, and the audit-log purge). **Export: three real gaps found and fixed** — `Quiz.dropouts`, `Quiz.finalizedAt`, `Question.enabled` were never shown; added via a new "Quiz info" tab rather than touching the shared `fillQuestionsSheet()` (which the pre-existing single-quiz import/export feature depends on for its column layout). Deliberately left out: the `BankQuestion` audit log (would leak other owners' emails, consistent with hiding co-owner identities elsewhere in this export) and a few low-value timestamps already covered by existing Started/time-taken columns.

### Sanitization: Symfony's AsciiSlugger instead of a hand-rolled regex
All user-controlled text that ends up in a zip entry path or downloaded filename (season/quiz names, account email) goes through a shared `Tvdt\Helpers\FilenameSanitizer`, backed by `symfony/string`'s `AsciiSlugger` (allowlist-based: only `A-Z`/`0-9` survive) instead of a denylist regex. Also fixed `BackofficeController::exportQuiz()`, a pre-existing endpoint with the same unsanitized-filename risk. Naming note: sanitized names are slugs (spaces → dashes, unicode ASCII-transliterated).

### Bug fix: "Delete account" wasn't actually deleting quiz data
`UserRepository::deleteUser()` was silently broken whenever a deleted season had real quiz activity: `QuizCandidate`/`GivenAnswer`/`Elimination` are `Gedmo\SoftDeleteable`, so cascading removal only set `deletedAt`, and the leftover rows caused a `ForeignKeyConstraintViolationException` against the hard-deleted `Candidate`/`Answer`, rolling back the entire deletion. Also fixed: `BankQuestion` audit-log rows (storing the editor's email) were never cleaned up. Both are now purged via bulk DQL before/after the cascade.

### Other
- Removed the "Public link identifier" (candidate `nameHash`) from the export — it's a quiz-access token, not export-worthy.
- `ZipArchive::open()`/`close()` failures are now checked (CodeRabbit findings) instead of silently producing an empty/corrupt zip, with temp-file cleanup on any failure path.

## Test plan
- [x] `just test` — full suite passes (204 tests)
- [x] `just phpstan` — no errors
- [x] `just fix-cs` / twig-cs-fixer — clean
- [x] `just rector --dry-run` — clean
- [x] `tests/Helpers/FilenameSanitizerTest.php`, `tests/Controller/Backoffice/BackofficeControllerTest.php`, `tests/Repository/UserRepositoryTest.php`, `tests/Service/DataExportServiceTest.php` cover sanitization, filename fix, hard-delete/audit-log purge, and the export contents (including the new Quiz info tab and the email-verification gate on both export endpoints)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a downloadable “Your data” ZIP archive in backoffice settings, including profile, owned seasons, quizzes, results, candidates, and question bank spreadsheets.
* **Bug Fixes**
  * Improved export filenames to be safer and more readable.
  * Enhanced user-deletion cleanup, including related records and audit history removal.
* **Documentation**
  * Updated the settings UI with clearer “Your data” download copy and email-verification warnings.
* **Tests**
  * Added end-to-end coverage for data downloads, filename sanitisation, and deletion/export cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->