### PR TITLE
Add reset progress action for a candidate's quiz attempt, and modal-based candidate editing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,15 @@ jobs:
         id: rector
         continue-on-error: true
         run: docker compose exec -T php vendor/bin/rector process --dry-run --no-progress-bar --output-format=github
+      - name: Translations
+        id: translations
+        continue-on-error: true
+        run: |
+          docker compose exec -T php bin/console translation:extract --force --format=xliff --sort=asc nl
+          if ! git diff --exit-code -- translations; then
+            echo "::error::Translations are out of date. Run 'just translations' and commit the changes."
+            exit 1
+          fi
       - name: Check HTTP reachability
         run: curl -v --fail-with-body http://localhost
       - name: Assert all checks passed
@@ -113,6 +122,7 @@ jobs:
           check "Twig Coding Style" "${{ steps.twig_cs.outcome }}"
           check "PHPStan"          "${{ steps.phpstan.outcome }}"
           check "Rector"           "${{ steps.rector.outcome }}"
+          check "Translations"     "${{ steps.translations.outcome }}"
           exit $failed
 
   tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,7 @@ GitHub Actions workflow (`.github/workflows/ci.yml`):
     - Twig-CS-Fixer style check
     - PHPStan static analysis
     - Rector dry-run
+    - Translation extraction check (fails if `translation:extract` produces uncommitted changes)
 3. **Integration Tests**:
     - Docker image build and start services
     - Database creation and migration

--- a/Justfile
+++ b/Justfile
@@ -61,9 +61,20 @@ up *args: init
 down *args:
     docker compose down --remove-orphans {{ args }}
 
-# Show the host ports assigned to this worktree (see `just init`)
+# Show the URLs (and DB connection) assigned to this worktree (see `just init`)
 ports:
-    @cat .env.local 2>/dev/null || echo "No .env.local yet, run 'just up' or 'just init' first."
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f .env.local ]; then
+        echo "No .env.local yet, run 'just up' or 'just init' first."
+        exit 0
+    fi
+    set -a
+    source .env.local
+    set +a
+    echo "Tvdt:      https://localhost:${HTTPS_PORT}"
+    echo "Mailpit:   http://localhost:${MAILPIT_PORT}"
+    echo "Spotlight: http://localhost:${SPOTLIGHT_PORT}"
 
 stop:
     docker compose stop

--- a/src/Controller/Backoffice/QuizController.php
+++ b/src/Controller/Backoffice/QuizController.php
@@ -409,8 +409,10 @@ class QuizController extends AbstractController
     )]
     public function resetCandidateProgress(Quiz $quiz, Candidate $candidate): RedirectResponse
     {
-        $this->givenAnswerRepository->deleteAllForCandidateInQuiz($quiz, $candidate);
-        $this->quizCandidateRepository->resetProgressForCandidate($quiz, $candidate);
+        $this->em->wrapInTransaction(function () use ($quiz, $candidate): void {
+            $this->givenAnswerRepository->deleteAllForCandidateInQuiz($quiz, $candidate);
+            $this->quizCandidateRepository->resetProgressForCandidate($quiz, $candidate);
+        });
 
         $this->addFlash(FlashType::Success, $this->translator->trans('Candidate progress reset'));
 

--- a/src/Controller/Backoffice/QuizController.php
+++ b/src/Controller/Backoffice/QuizController.php
@@ -25,6 +25,7 @@ use Tvdt\Entity\QuizCandidate;
 use Tvdt\Entity\Season;
 use Tvdt\Enum\FlashType;
 use Tvdt\Exception\ErrorClearingQuizException;
+use Tvdt\Repository\GivenAnswerRepository;
 use Tvdt\Repository\QuizCandidateRepository;
 use Tvdt\Repository\QuizRepository;
 use Tvdt\Security\Voter\SeasonVoter;
@@ -37,6 +38,7 @@ class QuizController extends AbstractController
         private readonly QuizRepository $quizRepository,
         private readonly TranslatorInterface $translator,
         private readonly QuizCandidateRepository $quizCandidateRepository,
+        private readonly GivenAnswerRepository $givenAnswerRepository,
         private readonly EntityManagerInterface $em,
     ) {}
 
@@ -393,6 +395,24 @@ class QuizController extends AbstractController
         $this->em->flush();
 
         $this->addFlash(FlashType::Success, $this->translator->trans('Candidate status updated'));
+
+        return $this->redirectToRoute('tvdt_backoffice_quiz_candidates_tab', ['seasonCode' => $quiz->season->seasonCode, 'quiz' => $quiz->id]);
+    }
+
+    #[IsCsrfTokenValid('reset_candidate_progress')]
+    #[IsGranted(SeasonVoter::EDIT, subject: 'quiz')]
+    #[Route(
+        '/backoffice/quiz/{quiz}/candidate/{candidate}/reset',
+        name: 'tvdt_backoffice_reset_candidate_progress',
+        requirements: ['quiz' => Requirement::UUID, 'candidate' => Requirement::UUID],
+        methods: ['POST'],
+    )]
+    public function resetCandidateProgress(Quiz $quiz, Candidate $candidate): RedirectResponse
+    {
+        $this->givenAnswerRepository->deleteAllForCandidateInQuiz($quiz, $candidate);
+        $this->quizCandidateRepository->resetProgressForCandidate($quiz, $candidate);
+
+        $this->addFlash(FlashType::Success, $this->translator->trans('Candidate progress reset'));
 
         return $this->redirectToRoute('tvdt_backoffice_quiz_candidates_tab', ['seasonCode' => $quiz->season->seasonCode, 'quiz' => $quiz->id]);
     }

--- a/src/Controller/Backoffice/SeasonController.php
+++ b/src/Controller/Backoffice/SeasonController.php
@@ -129,6 +129,8 @@ class SeasonController extends AbstractController
     )]
     public function addCandidates(Season $season, Request $request): Response
     {
+        $isTurboFrame = $request->headers->has('Turbo-Frame');
+
         $form = $this->createForm(AddCandidatesFormType::class);
         $form->handleRequest($request);
 
@@ -140,10 +142,18 @@ class SeasonController extends AbstractController
 
             $this->em->flush();
 
-            return $this->redirectToRoute('tvdt_backoffice_season', ['seasonCode' => $season->seasonCode]);
+            if ($isTurboFrame) {
+                return new Response('<turbo-frame id="add-candidates-modal-frame"></turbo-frame>');
+            }
+
+            return $this->redirectToRoute('tvdt_backoffice_season_candidates', ['seasonCode' => $season->seasonCode]);
         }
 
-        return $this->render('backoffice/season_add_candidates.html.twig', ['form' => $form, 'season' => $season]);
+        $template = $isTurboFrame
+            ? 'backoffice/season/_add_candidates_frame.html.twig'
+            : 'backoffice/season_add_candidates.html.twig';
+
+        return $this->render($template, ['form' => $form, 'season' => $season]);
     }
 
     #[IsCsrfTokenValid('rename_candidate')]

--- a/src/Form/AddCandidatesFormType.php
+++ b/src/Form/AddCandidatesFormType.php
@@ -19,7 +19,9 @@ class AddCandidatesFormType extends AbstractType
     {
         $builder
             ->add('candidates', TextareaType::class, [
-                'label' => $this->translator->trans('Candidates'), 'translation_domain' => false,
+                'label' => $this->translator->trans('Candidates'),
+                'help' => $this->translator->trans('One candidate per line'),
+                'translation_domain' => false,
             ])
         ;
     }

--- a/src/Repository/GivenAnswerRepository.php
+++ b/src/Repository/GivenAnswerRepository.php
@@ -6,7 +6,9 @@ namespace Tvdt\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Tvdt\Entity\Candidate;
 use Tvdt\Entity\GivenAnswer;
+use Tvdt\Entity\Quiz;
 
 /** @extends ServiceEntityRepository<GivenAnswer> */
 class GivenAnswerRepository extends ServiceEntityRepository
@@ -14,5 +16,16 @@ class GivenAnswerRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, GivenAnswer::class);
+    }
+
+    public function deleteAllForCandidateInQuiz(Quiz $quiz, Candidate $candidate): void
+    {
+        $givenAnswers = $this->findBy(['quiz' => $quiz, 'candidate' => $candidate]);
+
+        foreach ($givenAnswers as $givenAnswer) {
+            $this->getEntityManager()->remove($givenAnswer);
+        }
+
+        $this->getEntityManager()->flush();
     }
 }

--- a/src/Repository/QuizCandidateRepository.php
+++ b/src/Repository/QuizCandidateRepository.php
@@ -68,4 +68,15 @@ class QuizCandidateRepository extends ServiceEntityRepository
         $quizCandidate->penaltySeconds = $penalty;
         $this->getEntityManager()->flush();
     }
+
+    public function resetProgressForCandidate(Quiz $quiz, Candidate $candidate): void
+    {
+        $quizCandidate = $this->findOneBy(['candidate' => $candidate, 'quiz' => $quiz]);
+        if (!$quizCandidate instanceof QuizCandidate) {
+            return;
+        }
+
+        $quizCandidate->started = null;
+        $this->getEntityManager()->flush();
+    }
 }

--- a/templates/backoffice/quiz/tab_candidates_list.html.twig
+++ b/templates/backoffice/quiz/tab_candidates_list.html.twig
@@ -37,7 +37,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    <form action="{{ path('tvdt_backoffice_toggle_candidate', {quiz: quiz.id, candidate: candidate.id}) }}" method="POST">
+                    <form action="{{ path('tvdt_backoffice_toggle_candidate', {quiz: quiz.id, candidate: candidate.id}) }}" method="POST" class="d-inline">
                         <input type="hidden" name="_token" value="{{ csrf_token('toggle_candidate') }}">
                         <button type="submit" class="btn btn-sm btn-outline-secondary">
                             {% if quizCandidate == null or quizCandidate.active %}
@@ -47,6 +47,12 @@
                             {% endif %}
                         </button>
                     </form>
+                    {% if quizCandidate and quizCandidate.started %}
+                        <form action="{{ path('tvdt_backoffice_reset_candidate_progress', {quiz: quiz.id, candidate: candidate.id}) }}" method="POST" class="d-inline" onsubmit="return confirm('{{ 'Are you sure you want to reset progress for this candidate? Their given answers for this quiz will be deleted.'|trans|e('js') }}');">
+                            <input type="hidden" name="_token" value="{{ csrf_token('reset_candidate_progress') }}">
+                            <button type="submit" class="btn btn-sm btn-outline-danger">{{ 'Reset progress'|trans }}</button>
+                        </form>
+                    {% endif %}
                 </td>
             </tr>
         {% endfor %}

--- a/templates/backoffice/season/_add_candidates_frame.html.twig
+++ b/templates/backoffice/season/_add_candidates_frame.html.twig
@@ -1,0 +1,11 @@
+<turbo-frame id="add-candidates-modal-frame">
+    {{ form_start(form, {attr: {novalidate: 'novalidate'}}) }}
+    <div class="modal-body">
+        {{ form_row(form.candidates) }}
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
+        <button type="submit" class="btn btn-primary">{{ 'Submit'|trans }}</button>
+    </div>
+    {{ form_end(form) }}
+</turbo-frame>

--- a/templates/backoffice/season/tab_candidates.html.twig
+++ b/templates/backoffice/season/tab_candidates.html.twig
@@ -1,8 +1,10 @@
-<div class="row">
+<div class="row" data-controller="bo--modal" data-action="turbo:submit-end->bo--modal#frameSubmitEnd">
     <div class="col-md-6 col-12">
         <div class="mb-3">
-            <a class="btn btn-sm btn-outline-primary"
-               href="{{ path('tvdt_backoffice_add_candidates', {seasonCode: season.seasonCode}) }}">{{ 'Add Candidate'|trans }}</a>
+            <button type="button" class="btn btn-sm btn-outline-primary"
+                    data-action="click->bo--modal#open"
+                    data-src="{{ path('tvdt_backoffice_add_candidates', {seasonCode: season.seasonCode}) }}"
+                    data-modal-title="{{ 'Add Candidate'|trans }}">{{ 'Add Candidate'|trans }}</button>
         </div>
         <ul class="list-group mb-3">
             {% for candidate in season.candidates %}
@@ -17,7 +19,9 @@
                                 title="{{ 'Delete'|trans }}"><i class="bi bi-trash"></i></button>
                     </div>
 
-                    <div class="modal fade" id="renameCandidate-{{ candidate.id }}" data-bs-backdrop="static"
+                    <div class="modal fade" id="renameCandidate-{{ candidate.id }}"
+                         data-controller="bo--modal" data-bo--modal-target="modal"
+                         data-action="hidden.bs.modal->bo--modal#resetDirty"
                          tabindex="-1" aria-labelledby="renameCandidate-{{ candidate.id }}Label" aria-hidden="true">
                         <div class="modal-dialog">
                             <div class="modal-content">
@@ -31,7 +35,8 @@
                                         <input type="hidden" name="_token" value="{{ csrf_token('rename_candidate') }}">
                                         <label class="form-label" for="renameCandidateName-{{ candidate.id }}">{{ 'Name'|trans }}</label>
                                         <input type="text" class="form-control" id="renameCandidateName-{{ candidate.id }}"
-                                               name="name" value="{{ candidate.name }}" maxlength="16" required autofocus>
+                                               name="name" value="{{ candidate.name }}" maxlength="16" required autofocus
+                                               data-action="input->bo--modal#markDirty change->bo--modal#markDirty">
                                     </div>
                                     <div class="modal-footer">
                                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
@@ -69,6 +74,23 @@
                 {{ 'No candidates'|trans }}
             {% endfor %}
         </ul>
+
+        <div class="modal fade" tabindex="-1"
+             data-bo--modal-target="modal"
+             data-action="hidden.bs.modal->bo--modal#resetDirty"
+             aria-labelledby="addCandidatesModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-5" id="addCandidatesModalLabel">{{ 'Add Candidate'|trans }}</h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <turbo-frame id="add-candidates-modal-frame"
+                                 data-bo--modal-target="frame"
+                                 data-action="input->bo--modal#markDirty change->bo--modal#markDirty"></turbo-frame>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="col-md-6 col-12">
         {{ include('backoffice/help/season_candidates.html.twig') }}

--- a/tests/Controller/Backoffice/QuizControllerTest.php
+++ b/tests/Controller/Backoffice/QuizControllerTest.php
@@ -173,6 +173,47 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
         $this->assertTrue($updated->active);
     }
 
+    public function testResetCandidateProgressDeletesGivenAnswersAndClearsStarted(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $candidate = $this->getCandidate('Tom');
+
+        $quizCandidate = new QuizCandidate($quiz, $candidate);
+        $quizCandidate->started = new DateTimeImmutable();
+
+        $this->entityManager->persist($quizCandidate);
+        $firstQuestion = $quiz->questions->first();
+        $this->assertInstanceOf(Question::class, $firstQuestion);
+        $answer = $firstQuestion->answers->first();
+        $this->assertInstanceOf(Answer::class, $answer);
+        $this->entityManager->persist(new GivenAnswer($candidate, $quiz, $answer));
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s/candidates-list', $quiz->id));
+        self::assertResponseIsSuccessful();
+        $token = (string) $crawler->filter(\sprintf('form[action*="/%s/reset"] input[name="_token"]', $candidate->id))->first()->attr('value');
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/candidate/%s/reset', $quiz->id, $candidate->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects();
+        $this->entityManager->clear();
+
+        $updated = $this->entityManager->getRepository(QuizCandidate::class)->findOneBy([
+            'quiz' => $this->getQuizByName('Quiz 1'),
+            'candidate' => $this->getCandidate('Tom'),
+        ]);
+        $this->assertInstanceOf(QuizCandidate::class, $updated);
+        $this->assertNotInstanceOf(\DateTimeImmutable::class, $updated->started);
+
+        $remainingAnswers = $this->entityManager->getRepository(GivenAnswer::class)->findBy([
+            'quiz' => $quiz,
+            'candidate' => $candidate,
+        ]);
+        $this->assertCount(0, $remainingAnswers);
+    }
+
     public function testModifyCorrection(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');

--- a/tests/Controller/Backoffice/SeasonControllerTest.php
+++ b/tests/Controller/Backoffice/SeasonControllerTest.php
@@ -104,6 +104,42 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
         $this->assertNotInstanceOf(Candidate::class, $this->entityManager->getRepository(Candidate::class)->find($candidateId));
     }
 
+    public function testAddCandidates(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/backoffice/season/krtek/add-candidate');
+        $form = $this->client->getCrawler()->filter('form')->form([
+            'add_candidates_form[candidates]' => "Nora\nPiet",
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/candidates');
+        $this->entityManager->clear();
+
+        $season = $this->entityManager->getRepository(Season::class)->findOneBy(['seasonCode' => 'krtek']);
+        $this->assertInstanceOf(Season::class, $season);
+        $names = array_map(static fn (Candidate $candidate): string => $candidate->name, $season->candidates->toArray());
+        $this->assertContains('Nora', $names);
+        $this->assertContains('Piet', $names);
+    }
+
+    public function testAddCandidatesViaTurboFrameReturnsEmptyFrame(): void
+    {
+        $this->client->xmlHttpRequest(Request::METHOD_GET, '/backoffice/season/krtek/add-candidate', server: ['HTTP_TURBO-FRAME' => 'add-candidates-modal-frame']);
+        $form = $this->client->getCrawler()->filter('form')->form([
+            'add_candidates_form[candidates]' => 'Sanne',
+        ]);
+        $this->client->submit($form, [], ['HTTP_TURBO-FRAME' => 'add-candidates-modal-frame']);
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('<turbo-frame id="add-candidates-modal-frame"></turbo-frame>', (string) $this->client->getResponse()->getContent());
+        $this->entityManager->clear();
+
+        $season = $this->entityManager->getRepository(Season::class)->findOneBy(['seasonCode' => 'krtek']);
+        $this->assertInstanceOf(Season::class, $season);
+        $names = array_map(static fn (Candidate $candidate): string => $candidate->name, $season->candidates->toArray());
+        $this->assertContains('Sanne', $names);
+    }
+
     public function testRenameCandidateIsDeniedForNonOwner(): void
     {
         $candidate = $this->getCandidate('Tom');

--- a/translations/messages+intl-icu.nl.xliff
+++ b/translations/messages+intl-icu.nl.xliff
@@ -117,6 +117,10 @@
         <source>Are you sure you want to delete this quiz?</source>
         <target>Weet je zeker dat je deze test wilt verwijderen?</target>
       </trans-unit>
+      <trans-unit id="6XTrab." resname="Are you sure you want to reset progress for this candidate? Their given answers for this quiz will be deleted.">
+        <source>Are you sure you want to reset progress for this candidate? Their given answers for this quiz will be deleted.</source>
+        <target>Weet je zeker dat je de voortgang van deze kandidaat wilt resetten? De ingevulde antwoorden voor deze test worden verwijderd.</target>
+      </trans-unit>
       <trans-unit id="4bcq6sL" resname="Assign">
         <source>Assign</source>
         <target>Toewijzen</target>
@@ -160,6 +164,10 @@
       <trans-unit id="TiTLBGW" resname="Candidate not found">
         <source>Candidate not found</source>
         <target>Kandidaat niet gevonden</target>
+      </trans-unit>
+      <trans-unit id="fl.hjdA" resname="Candidate progress reset">
+        <source>Candidate progress reset</source>
+        <target>Voortgang kandidaat gereset</target>
       </trans-unit>
       <trans-unit id="QH4e_Ho" resname="Candidate renamed">
         <source>Candidate renamed</source>
@@ -541,6 +549,10 @@
         <source>Number of dropouts:</source>
         <target>Aantal afvallers:</target>
       </trans-unit>
+      <trans-unit id="vxaREnf" resname="One candidate per line">
+        <source>One candidate per line</source>
+        <target>Eén kandidaat per regel</target>
+      </trans-unit>
       <trans-unit id="_SqArFZ" resname="Open">
         <source>Open</source>
         <target>Openen</target>
@@ -760,6 +772,10 @@
       <trans-unit id="9JCvQkt" resname="Reset password">
         <source>Reset password</source>
         <target>Wachtwoord herstellen</target>
+      </trans-unit>
+      <trans-unit id="SSMxy68" resname="Reset progress">
+        <source>Reset progress</source>
+        <target>Voortgang resetten</target>
       </trans-unit>
       <trans-unit id="eyayNGN" resname="Reset your password">
         <source>Reset your password</source>


### PR DESCRIPTION
## Summary
- Adds a backoffice action to reset a single candidate's progress on a quiz: deletes their `GivenAnswer`s and clears `QuizCandidate::$started` so they can retake it.
- Adds a "Reset progress" button in the quiz candidates tab, shown only for candidates who have started the quiz.
- Fixes the rename-candidate modal always blocking backdrop-click/Escape dismissal (hardcoded static backdrop); it now only blocks dismissal once the name field has actually been edited, reusing the existing `bo--modal` dirty-tracking controller.
- Moves "Add Candidate" from a full-page navigation into a turbo-frame modal (same pattern used for editing quiz questions), with the full-page form kept as a fallback for non-JS/turbo requests. Adds a help hint clarifying one candidate per line.
- Translates the new/previously-missed Dutch strings, and adds a CI step that re-runs `translation:extract` and fails the build if it produces uncommitted changes, so untranslated strings can't slip through again.

Closes #20

## Test plan
- [x] `just test tests/Controller/Backoffice/QuizControllerTest.php` — `testResetCandidateProgressDeletesGivenAnswersAndClearsStarted` passes
- [x] `just test tests/Controller/Backoffice/SeasonControllerTest.php` — new `testAddCandidates` / `testAddCandidatesViaTurboFrameReturnsEmptyFrame` tests pass
- [x] `just test` — full suite passes (277 tests)
- [x] `just phpstan` — no errors
- [x] `just fix-cs` / twig-cs-fixer — no issues
- [x] `just rector --dry-run` — no pending changes
- [x] `just translations` — no leftover diff after translating new strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Back-office users can reset a candidate’s quiz progress, removing their answers and clearing their started status.
  - Added a confirmation prompt before resetting progress.
  - Added a Turbo-powered modal for adding candidates without leaving the candidates page.
  - Improved rename-candidate modal behaviour and feedback.

- **Bug Fixes**
  - Candidate addition now responds correctly for both full-page and Turbo Frame requests.

- **Chores**
  - CI now checks that translations are up to date.
  - Added Dutch translations for candidate management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->