### PR TITLE
fix: support more than 25 columns in data export sheets

### DIFF
--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -263,7 +263,7 @@ class DataExportService
         }
 
         $lastColumnIndex = 1 + \count($questions);
-        foreach (range('A', Coordinate::stringFromColumnIndex($lastColumnIndex)) as $column) {
+        foreach ($this->columnLetters($lastColumnIndex) as $column) {
             $sheet->getColumnDimension($column)->setWidth(30);
             $sheet->getStyle($column.':'.$column)->getAlignment()->setWrapText(true);
         }
@@ -297,7 +297,7 @@ class DataExportService
             ++$row;
         }
 
-        foreach (range('A', Coordinate::stringFromColumnIndex(2 + \count($candidates))) as $column) {
+        foreach ($this->columnLetters(2 + \count($candidates)) as $column) {
             $sheet->getColumnDimension($column)->setAutoSize(true);
         }
     }
@@ -405,7 +405,7 @@ class DataExportService
         }
 
         $lastColumnIndex = $answerStartColumnIndex + max(1, 2 * $maxAnswers);
-        foreach (range('A', Coordinate::stringFromColumnIndex($lastColumnIndex)) as $column) {
+        foreach ($this->columnLetters($lastColumnIndex) as $column) {
             $sheet->getColumnDimension($column)->setAutoSize(true);
         }
     }
@@ -424,6 +424,22 @@ class DataExportService
         foreach (['A', 'B', 'C'] as $column) {
             $sheet->getColumnDimension($column)->setAutoSize(true);
         }
+    }
+
+    /**
+     * Column letters from 'A' up to and including the given 1-based column index.
+     * Unlike range('A', ...), this works past 'Z' (e.g. index 27 => 'AA').
+     *
+     * @return list<string>
+     */
+    private function columnLetters(int $lastColumnIndex): array
+    {
+        $letters = [];
+        for ($columnIndex = 1; $columnIndex <= $lastColumnIndex; ++$columnIndex) {
+            $letters[] = Coordinate::stringFromColumnIndex($columnIndex);
+        }
+
+        return $letters;
     }
 
     /** @throws FilesystemException */

--- a/tests/Service/DataExportServiceRawAnswersColumnsTest.php
+++ b/tests/Service/DataExportServiceRawAnswersColumnsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Tvdt\Entity\Question;
+use Tvdt\Entity\Quiz;
+use Tvdt\Repository\QuizRepository;
+use Tvdt\Service\DataExportService;
+use Tvdt\Service\QuizSpreadsheetService;
+
+/**
+ * Reproduces a Sentry warning (PHP-SYMFONY-3Z): with more than 25 questions, the last raw-answers
+ * column goes past 'Z' (e.g. 'AA'), and range('A', 'AA') is invalid because range()'s second argument
+ * must be a single byte.
+ */
+#[CoversClass(DataExportService::class)]
+final class DataExportServiceRawAnswersColumnsTest extends TestCase
+{
+    public function testFillRawAnswersSheetHandlesMoreThanTwentyFiveQuestions(): void
+    {
+        $subject = new DataExportService(
+            $this->createStub(EntityManagerInterface::class),
+            $this->createStub(QuizSpreadsheetService::class),
+            $this->createStub(QuizRepository::class),
+        );
+
+        $quiz = new Quiz();
+        for ($i = 0; $i < 26; ++$i) {
+            $question = new Question();
+            $question->question = 'Question '.($i + 1);
+            $quiz->addQuestion($question);
+        }
+
+        $sheet = new Spreadsheet()->getActiveSheet();
+
+        $method = new \ReflectionMethod(DataExportService::class, 'fillRawAnswersSheet');
+        $method->invoke($subject, $sheet, $quiz);
+
+        $this->assertEqualsWithDelta(30.0, $sheet->getColumnDimension('AA')->getWidth(), \PHP_FLOAT_EPSILON);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes Sentry issue [PHP-SYMFONY-3Z](https://tijd-voor-de-test.sentry.io/issues/133451757/): `range('A', Coordinate::stringFromColumnIndex($n))` in `DataExportService` throws a PHP warning once a sheet needs more than 26 columns, because `range()`'s end argument silently truncates to a single byte (e.g. `'AA'` becomes `'A'`), so the last column of the raw-answers grid (one column per question) is mis-sized whenever a quiz has 26+ questions.
- Replaces the three occurrences of that pattern with a `columnLetters()` helper that walks column indexes via `Coordinate::stringFromColumnIndex`, which correctly handles multi-letter columns.

## Test plan
- [x] Added `DataExportServiceRawAnswersColumnsTest`, which reproduces the warning with a 26-question quiz and asserts column `'AA'` is sized correctly (failed with the exact Sentry warning before the fix, passes after).
- [x] `just test` — full suite passes (275 tests).
- [x] `just phpstan` — no errors.
- [x] `just fix-cs` — no changes needed.