### PR TITLE
Share the self-signed Caddy CA/cert across worktrees

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,11 +4,18 @@ set dotenv-filename := ".env.local"
 
 # Generate a per-worktree COMPOSE_PROJECT_NAME, IMAGES_PREFIX and free host ports in .env.local,
 # so multiple worktrees/checkouts of this repo can run `just up` at the same time without their
-# containers, volumes, images or ports colliding. Safe to re-run; no-ops if already configured.
+# containers, volumes, images or ports colliding. Also points CADDY_DATA_DIR at a location shared
+# by all worktrees of the same clone, so they reuse one self-signed CA/cert instead of generating
+# their own. Safe to re-run; no-ops if already configured.
 init:
     #!/usr/bin/env bash
     set -euo pipefail
     if [ -f .env.local ] && grep -q '^COMPOSE_PROJECT_NAME=' .env.local; then
+        if ! grep -q '^CADDY_DATA_DIR=' .env.local; then
+            git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir)
+            echo "CADDY_DATA_DIR=${git_common_dir}/tvdt-caddy-data" >> .env.local
+            echo "Backfilled CADDY_DATA_DIR into existing .env.local."
+        fi
         echo ".env.local already configured for this worktree, skipping (delete it to regenerate)."
         exit 0
     fi
@@ -39,6 +46,11 @@ init:
     postgres_port=$(free_port 5430 5529)
     mailpit_port=$(free_port 8025 8124)
     spotlight_port=$(free_port 8969 9068)
+    # .git is shared by all worktrees of the same clone, so anchoring the Caddy data dir
+    # (self-signed CA + TLS certs) there instead of under the worktree lets every worktree
+    # reuse the same CA, avoiding a fresh cert (and a fresh `just trust-cert`) per checkout.
+    git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir)
+    caddy_data_dir="${git_common_dir}/tvdt-caddy-data"
     {
         echo "COMPOSE_PROJECT_NAME=${project}"
         echo "IMAGES_PREFIX=${project}-"
@@ -47,6 +59,7 @@ init:
         echo "POSTGRES_PORT=${postgres_port}"
         echo "MAILPIT_PORT=${mailpit_port}"
         echo "SPOTLIGHT_PORT=${spotlight_port}"
+        echo "CADDY_DATA_DIR=${caddy_data_dir}"
     } >> .env.local
     echo "Generated .env.local for this worktree:"
     cat .env.local
@@ -128,8 +141,13 @@ install-hooks:
     chmod +x .githooks/pre-commit
     @echo "Pre-commit hook installed."
 
-trust-cert:
+trust-cert: init
+    #!/usr/bin/env bash
+    set -euo pipefail
+    set -a
+    source .env.local
+    set +a
     sudo security add-trusted-cer -d \
-    -r trustRoot \
-    -k "$HOME/Library/Keychains/login.keychain" \
-    ./frankenphp/data/caddy/pki/authorities/local/root.crt
+        -r trustRoot \
+        -k "$HOME/Library/Keychains/login.keychain" \
+        "${CADDY_DATA_DIR:-./frankenphp/data}/caddy/pki/authorities/local/root.crt"

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -10,7 +10,7 @@ services:
       - ~/.composer/cache:/root/.composer/cache
       - ./frankenphp/Caddyfile:/etc/caddy/Caddyfile:ro
       - ./frankenphp/conf.d/20-app.dev.ini:/usr/local/etc/php/app.conf.d/20-app.dev.ini:ro
-      - ./frankenphp/data:/data
+      - ${CADDY_DATA_DIR:-./frankenphp/data}:/data
       - sass:/app/var/sass
     environment:
       MERCURE_EXTRA_DIRECTIVES: demo


### PR DESCRIPTION
## Summary
- Each worktree previously bind-mounted its own `frankenphp/data`, so Caddy minted a fresh self-signed CA/cert per checkout, requiring `just trust-cert` to be re-run every time a new worktree was created.
- `just init` now writes `CADDY_DATA_DIR` into `.env.local`, anchored at the shared `.git` common dir (`git rev-parse --path-format=absolute --git-common-dir`) rather than the per-worktree directory, so all worktrees of the same clone reuse the same CA/cert. Existing `.env.local` files get backfilled automatically.
- `compose.override.yaml`'s `/data` bind mount and `just trust-cert` now use `CADDY_DATA_DIR`.

## Test plan
- [x] `just init` backfills `CADDY_DATA_DIR` into an existing `.env.local`
- [x] `docker compose config` resolves the `/data` bind mount to the shared `.git/tvdt-caddy-data` path
- [ ] Spin up a second worktree and confirm it reuses the same CA (no new `just trust-cert` needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Development setup now shares Caddy security certificates across worktrees of the same clone.
  - Environment configuration automatically records the shared Caddy data location for new and existing worktrees.
  - Container data storage now follows the configured Caddy data location, while retaining the existing default when unset.

- **Bug Fixes**
  - Certificate trust setup now initialises the environment first and locates the correct certificate automatically, improving reliability across worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->