### PR TITLE
Automate TypeScript asset compilation in dev

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -71,6 +71,9 @@ up *args: init
     set +a
     docker compose up -d {{ args }}
 
+compose *args:
+    docker compose {{ args }}
+
 down *args:
     docker compose down --remove-orphans {{ args }}
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -12,6 +12,7 @@ services:
       - ./frankenphp/conf.d/20-app.dev.ini:/usr/local/etc/php/app.conf.d/20-app.dev.ini:ro
       - ${CADDY_DATA_DIR:-./frankenphp/data}:/data
       - sass:/app/var/sass
+      - typescript:/app/var/typescript
     environment:
       MERCURE_EXTRA_DIRECTIVES: demo
       # See https://xdebug.org/docs/all_settings#mode
@@ -49,7 +50,23 @@ services:
       - -v
     healthcheck:
       disable: true
-  
+
+  typescript:
+    image: ${IMAGES_PREFIX:-}app-php
+    volumes:
+      - ./:/app:ro
+      - typescript:/app/var/typescript
+    entrypoint: ''
+    depends_on:
+      - php
+    command:
+      - bin/console
+      - typescript:build
+      - --watch
+      - -v
+    healthcheck:
+      disable: true
+
   ###> symfony/mercure-bundle ###
   ###< symfony/mercure-bundle ###
   
@@ -77,3 +94,4 @@ services:
 
 volumes:
   sass:
+  typescript:


### PR DESCRIPTION
## Summary
- Adds a `typescript` watch service to `compose.override.yaml`, mirroring the existing `sass` watch service, running `bin/console typescript:build --watch` continuously.
- Shares a named `typescript` volume between `php` and `typescript` at `/app/var/typescript` — needed because the Dockerfile's `VOLUME /app/var/` gives every container its own private, unsynced `/app/var`, so a plain bind mount alone doesn't propagate compiled output to `php`.
- Adds a `just compose` passthrough recipe for ad-hoc `docker compose` commands (logs, ps, top, etc.) using the worktree's env.

Before this, a fresh checkout or worktree (or after `just clean`) would 500 on any page rendering a TS asset (e.g. `quiz/base.html.twig`) until someone remembered to manually run `bin/console typescript:build`. Now it builds automatically on `just up` and rebuilds on file changes, same as sass.

## Test plan
- [x] `just up` on a fresh volume: `typescript` service downloads SWC and compiles, `https://localhost:8443/` returns 200 with no exception.
- [x] `just stop` / `just up` again: site stays up immediately (no rebuild needed, named volume persists).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated TypeScript watch service to automatically rebuild TypeScript changes during development.
  - TypeScript build output is now persisted and shared with the application service.

- **Developer Experience**
  - Added a convenient command for forwarding options directly to the container orchestration tool.
  - Existing development startup and shutdown behaviour remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->