### PR TITLE
Hotfix: deploy crash-loop from duplicate given_answer rows

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,15 @@
 #!/usr/bin/env zsh
 setopt ERR_EXIT PIPE_FAIL NOUNSET
 
+# Load the per-worktree COMPOSE_PROJECT_NAME etc. (see Justfile's dotenv-load) so
+# docker compose resolves this worktree's running services instead of falling
+# back to a directory-name-derived project with nothing running.
+if [[ -f .env.local ]]; then
+    set -a
+    source .env.local
+    set +a
+fi
+
 # Collect staged PHP and Twig files
 STAGED_PHP=()
 while IFS= read -r file; do

--- a/migrations/Version20260713194340.php
+++ b/migrations/Version20260713194340.php
@@ -33,6 +33,24 @@ final class Version20260713194340 extends AbstractMigration
                   CONSTRAINT FK_9AC61A301E27F6BF FOREIGN KEY (question_id) REFERENCES question (id) NOT DEFERRABLE
             SQL);
         $this->addSql('CREATE INDEX IDX_9AC61A301E27F6BF ON given_answer (question_id)');
+        // Legacy data can contain duplicate (candidate, question) answers predating this constraint;
+        // soft-delete all but the most recent per pair so the unique index below can be created.
+        $this->addSql(<<<'SQL'
+                UPDATE given_answer
+                SET deleted_at = NOW()
+                WHERE id IN (
+                    SELECT id
+                    FROM (
+                        SELECT id, ROW_NUMBER() OVER (
+                            PARTITION BY candidate_id, question_id
+                            ORDER BY created DESC, id DESC
+                        ) AS rn
+                        FROM given_answer
+                        WHERE deleted_at IS NULL
+                    ) ranked
+                    WHERE ranked.rn > 1
+                )
+            SQL);
         $this->addSql(<<<'SQL'
                 CREATE UNIQUE INDEX UNIQ_9AC61A3091BD87811E27F6BF ON given_answer (candidate_id, question_id)
                 WHERE


### PR DESCRIPTION
## Summary
- The app container was crash-looping on deploy: migration `Version20260713194340` adds a unique index on `given_answer(candidate_id, question_id)`, but the live database has legacy duplicate rows predating this constraint, so the `CREATE UNIQUE INDEX` fails with a `23505` violation and (with `--all-or-nothing`) the whole migration rolls back on every restart.
- The app itself already enforces this invariant correctly on new answers (`QuizController::quizPage` catches `UniqueConstraintViolationException`, and `findNextQuestionForCandidate` skips already-answered questions), so this is stale data, not an ongoing bug.
- Fix: before creating the unique index, soft-delete all but the most recent live `given_answer` per `(candidate_id, question_id)` pair. Already soft-deleted duplicates are untouched (the index is a partial index on `deleted_at IS NULL`, so they were never a conflict).
- Bonus fix: `.githooks/pre-commit` never exported `.env.local`, so `docker compose exec/run` fell back to the wrong compose project and spun up an uncached one-off container, breaking Rector for anyone using the documented per-worktree setup. Fixed to `set -a; source .env.local; set +a`, matching the Justfile's `dotenv-load` behavior.

## Test plan
- [x] Validated the new dedup SQL syntax in a rolled-back transaction against a local DB
- [x] `just phpstan` — no errors
- [x] `just fix-cs` — clean
- [ ] Confirm on the affected deploy target that the migration now applies past the previously failing duplicate row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of legacy answer records by retaining the latest response for each candidate and question while safely marking older duplicates as deleted.
  - Strengthened data integrity when enforcing unique active answers, reducing the risk of conflicting or repeated responses.

- **Chores**
  - Improved development environment setup so worktree-specific settings are applied consistently during pre-commit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->