### PR TITLE
Prefill forgot-password email from login field

### DIFF
--- a/assets/controllers/forgot_password_controller.ts
+++ b/assets/controllers/forgot_password_controller.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['email', 'link'];
+
+    declare readonly emailTarget: HTMLInputElement;
+    declare readonly linkTarget: HTMLAnchorElement;
+
+    connect(): void {
+        this.prefill();
+    }
+
+    prefill(): void {
+        if (!this.emailTarget.value) {
+            return;
+        }
+
+        const url = new URL(this.linkTarget.href);
+        url.searchParams.set('email', this.emailTarget.value);
+        this.linkTarget.href = url.href;
+    }
+}

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -38,7 +38,9 @@ final class ResetPasswordController extends AbstractController
     #[Route('/reset-password', name: 'tvdt_forgot_password_request')]
     public function request(Request $request): Response
     {
-        $form = $this->createForm(ResetPasswordRequestFormType::class);
+        $form = $this->createForm(ResetPasswordRequestFormType::class, [
+            'email' => $request->query->get('email', ''),
+        ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/templates/backoffice/login/login.html.twig
+++ b/templates/backoffice/login/login.html.twig
@@ -3,12 +3,13 @@
 {% block title %}Log in{% endblock %}
 
 {% block body %}
-    <form method="post">
+    <form method="post" data-controller="forgot-password">
         <h3 class="mb-3">{{ 'Please sign in'|trans }}</h3>
         <div class="mb-3">
             <label for="username" class="form-label">{{ 'Email'|trans }}</label>
             <input type="email" value="{{ last_username }}" name="_username" id="username" class="form-control"
-                   autocomplete="email" required autofocus>
+                   autocomplete="email" required autofocus
+                   data-forgot-password-target="email" data-action="input->forgot-password#prefill">
         </div>
 
         <div class="mb-3">
@@ -32,6 +33,6 @@
         <a href="{{ path('tvdt_register') }}"
            class="btn btn-link">{{ 'Create an account'|trans }}</a>
         <a href="{{ path('tvdt_forgot_password_request') }}"
-           class="btn btn-link">{{ 'Forgot your password?'|trans }}</a>
+           class="btn btn-link" data-forgot-password-target="link">{{ 'Forgot your password?'|trans }}</a>
     </form>
 {% endblock %}

--- a/tests/Controller/ResetPasswordControllerTest.php
+++ b/tests/Controller/ResetPasswordControllerTest.php
@@ -23,6 +23,15 @@ final class ResetPasswordControllerTest extends AbstractControllerWebTestCase
         $this->assertSelectorExists('form');
     }
 
+    public function testRequestPagePrefillsEmailFromQueryParameter(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/reset-password?email=test@example.org');
+
+        $this->assertResponseIsSuccessful();
+        $emailInput = $this->client->getCrawler()->filter('input[name="reset_password_request_form[email]"]');
+        $this->assertSame('test@example.org', $emailInput->attr('value'));
+    }
+
     /** @return iterable<string, array{string}> */
     public static function emailProvider(): iterable
     {


### PR DESCRIPTION
## Summary
- Clicking "Forgot your password?" on the login page now carries over whatever email was typed into the login form's username field, prefilling the reset-password request form.
- The value only exists client-side until the login form is submitted (a separate request from reset-password), so a small Stimulus controller (`forgot_password_controller.ts`) sets the email as a query param on the link before navigation. `ResetPasswordController::request()` reads `?email=` to prefill the form's initial data.

## Test plan
- [x] `just test tests/Controller/ResetPasswordControllerTest.php` (new test asserts the email input is prefilled from the query param)
- [x] `just test` (full suite, 303 tests pass)
- [x] `just phpstan`, `just fix-cs`, `deno fmt/lint/check` on the new TS file