### PR TITLE
Fix N+1 on quiz candidate-answer mapping page

### DIFF
--- a/src/Controller/Backoffice/QuizController.php
+++ b/src/Controller/Backoffice/QuizController.php
@@ -148,11 +148,26 @@ class QuizController extends AbstractController
     )]
     public function candidates_question(Season $season, Quiz $quiz, Question $question): Response
     {
+        // Eager-load answers' candidates in one query to avoid an N+1 when the
+        // template checks `answer.candidates.contains(candidate)` per answer/candidate pair.
+        $fetchedQuiz = $this->quizRepository->fetchWithQuestionsAndCandidates($quiz->id);
+
+        $fetchedQuestion = null;
+        foreach ($fetchedQuiz->questions as $candidateQuestion) {
+            if ($candidateQuestion->id->equals($question->id)) {
+                $fetchedQuestion = $candidateQuestion;
+
+                break;
+            }
+        }
+
+        \assert($fetchedQuestion instanceof Question);
+
         return $this->render('backoffice/quiz.html.twig', [
             'season' => $season,
             'quiz' => $quiz,
-            'question' => $question,
-            'candidates' => $season->candidates,
+            'question' => $fetchedQuestion,
+            'candidates' => $fetchedQuiz->season->candidates,
             'activeTab' => 'answers',
             'template' => 'backoffice/quiz/tab_candidates.html.twig',
         ]);


### PR DESCRIPTION
## Summary
- Confirmed via profiler token `2f51c9` (route `tvdt_backoffice_quiz_candidates_question`): the same `candidate INNER JOIN answer_candidate WHERE answer_candidate.answer_id = ?` query ran once per answer (5x for a 5-answer question).
- Root cause: `templates/backoffice/quiz/tab_candidates.html.twig` calls `answer.candidates.contains(candidate)` per candidate/answer pair, which lazily initializes each answer's `candidates` collection on first access.
- Fix: `QuizController::candidates_question()` now loads the quiz via the existing `QuizRepository::fetchWithQuestionsAndCandidates()`, which already eager-joins `answers.candidates` (and `season.candidates`) for the same reason on the error-checking path — reused rather than adding a new query method.

## Test plan
- [x] `just test tests/Controller/Backoffice/QuizControllerTest.php` (existing coverage for this page still passes)
- [x] `just test` (full suite, 302 tests pass)
- [x] `just phpstan`