### PR TITLE
Elimination delete/screen-log, quiz results UX, and demo fixtures

### DIFF
--- a/assets/controllers/bo/prepare_elimination_controller.ts
+++ b/assets/controllers/bo/prepare_elimination_controller.ts
@@ -1,0 +1,12 @@
+import { Controller } from '@hotwired/stimulus';
+import { Modal } from 'bootstrap';
+
+export default class extends Controller {
+    static targets = ['deleteModal'];
+
+    declare readonly deleteModalTarget: HTMLElement;
+
+    deleteElimination(): void {
+        Modal.getOrCreateInstance(this.deleteModalTarget).show();
+    }
+}

--- a/assets/styles/backoffice.scss
+++ b/assets/styles/backoffice.scss
@@ -4,6 +4,18 @@
 
 .modal-content > turbo-frame { display: contents; }
 
+.colour-select {
+  &:has(option[value="green"]:checked) {
+    background-color: var(--bs-success);
+    color: #fff;
+  }
+
+  &:has(option[value="red"]:checked) {
+    background-color: var(--bs-danger);
+    color: #fff;
+  }
+}
+
 .release-notes {
   overflow-wrap: break-word;
 

--- a/migrations/Version20260721193523.php
+++ b/migrations/Version20260721193523.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/** Auto-generated Migration: Please modify to your needs! */
+final class Version20260721193523 extends AbstractMigration
+{
+    #[\Override]
+    public function getDescription(): string
+    {
+        return 'Add elimination_screen_view to record which candidate screens were shown, in what order and with what colour';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE elimination_screen_view (id UUID NOT NULL, created TIMESTAMP(0) WITH TIME ZONE NOT NULL, colour VARCHAR(255) NOT NULL, elimination_id UUID NOT NULL, candidate_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_7CC14118A862750D ON elimination_screen_view (elimination_id)');
+        $this->addSql('CREATE INDEX IDX_7CC1411891BD8781 ON elimination_screen_view (candidate_id)');
+        $this->addSql('ALTER TABLE elimination_screen_view ADD CONSTRAINT FK_7CC14118A862750D FOREIGN KEY (elimination_id) REFERENCES elimination (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE elimination_screen_view ADD CONSTRAINT FK_7CC1411891BD8781 FOREIGN KEY (candidate_id) REFERENCES candidate (id) NOT DEFERRABLE');
+    }
+
+    #[\Override]
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE elimination_screen_view DROP CONSTRAINT FK_7CC14118A862750D');
+        $this->addSql('ALTER TABLE elimination_screen_view DROP CONSTRAINT FK_7CC1411891BD8781');
+        $this->addSql('DROP TABLE elimination_screen_view');
+    }
+}

--- a/migrations/Version20260721193523.php
+++ b/migrations/Version20260721193523.php
@@ -22,7 +22,7 @@ final class Version20260721193523 extends AbstractMigration
         $this->addSql('CREATE INDEX IDX_7CC14118A862750D ON elimination_screen_view (elimination_id)');
         $this->addSql('CREATE INDEX IDX_7CC1411891BD8781 ON elimination_screen_view (candidate_id)');
         $this->addSql('ALTER TABLE elimination_screen_view ADD CONSTRAINT FK_7CC14118A862750D FOREIGN KEY (elimination_id) REFERENCES elimination (id) ON DELETE CASCADE NOT DEFERRABLE');
-        $this->addSql('ALTER TABLE elimination_screen_view ADD CONSTRAINT FK_7CC1411891BD8781 FOREIGN KEY (candidate_id) REFERENCES candidate (id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE elimination_screen_view ADD CONSTRAINT FK_7CC1411891BD8781 FOREIGN KEY (candidate_id) REFERENCES candidate (id) ON DELETE CASCADE NOT DEFERRABLE');
     }
 
     #[\Override]

--- a/src/Controller/Backoffice/PrepareEliminationController.php
+++ b/src/Controller/Backoffice/PrepareEliminationController.php
@@ -13,16 +13,22 @@ use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Tvdt\Controller\AbstractController;
+use Tvdt\Dto\Result;
 use Tvdt\Entity\Elimination;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Enum\FlashType;
 use Tvdt\Factory\EliminationFactory;
+use Tvdt\Repository\QuizRepository;
 use Tvdt\Security\Voter\SeasonVoter;
 
 final class PrepareEliminationController extends AbstractController
 {
-    public function __construct(private readonly EliminationFactory $eliminationFactory, private readonly EntityManagerInterface $em) {}
+    public function __construct(
+        private readonly EliminationFactory $eliminationFactory,
+        private readonly EntityManagerInterface $em,
+        private readonly QuizRepository $quizRepository,
+    ) {}
 
     #[IsCsrfTokenValid('prepare_elimination')]
     #[IsGranted(SeasonVoter::ELIMINATION, 'quiz')]
@@ -65,7 +71,33 @@ final class PrepareEliminationController extends AbstractController
         return $this->render('backoffice/prepare_elimination/index.html.twig', [
             'controller_name' => 'PrepareEliminationController',
             'elimination' => $elimination,
+            'candidates' => $this->getOrderedCandidates($elimination),
         ]);
+    }
+
+    /**
+     * The candidates in an elimination (name => colour), ordered like the results list (score desc, time asc), each
+     * paired with their live score/time so both can be shown while preparing the elimination. A candidate can be
+     * missing a result if their given answers were reset after the elimination was prepared.
+     *
+     * @return array<string, ?Result>
+     */
+    private function getOrderedCandidates(Elimination $elimination): array
+    {
+        $resultsByName = [];
+        foreach ($this->quizRepository->getScores($elimination->quiz) as $result) {
+            $resultsByName[$result->name] = $result;
+        }
+
+        $candidates = array_intersect_key($resultsByName, $elimination->data);
+
+        foreach (array_keys($elimination->data) as $name) {
+            if (!\array_key_exists($name, $candidates)) {
+                $candidates[$name] = null;
+            }
+        }
+
+        return $candidates;
     }
 
     #[IsCsrfTokenValid('delete_elimination')]

--- a/src/Controller/Backoffice/PrepareEliminationController.php
+++ b/src/Controller/Backoffice/PrepareEliminationController.php
@@ -19,6 +19,7 @@ use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Enum\FlashType;
 use Tvdt\Factory\EliminationFactory;
+use Tvdt\Repository\EliminationRepository;
 use Tvdt\Repository\QuizRepository;
 use Tvdt\Security\Voter\SeasonVoter;
 
@@ -28,6 +29,7 @@ final class PrepareEliminationController extends AbstractController
         private readonly EliminationFactory $eliminationFactory,
         private readonly EntityManagerInterface $em,
         private readonly QuizRepository $quizRepository,
+        private readonly EliminationRepository $eliminationRepository,
     ) {}
 
     #[IsCsrfTokenValid('prepare_elimination')]
@@ -67,6 +69,9 @@ final class PrepareEliminationController extends AbstractController
 
             return $this->redirectToRoute('tvdt_prepare_elimination_view', ['elimination' => $elimination->id]);
         }
+
+        // Eager-load screenViews.candidate in one query to avoid an N+1 when the screen-view log table renders.
+        $this->eliminationRepository->fetchWithScreenViewCandidates($elimination->id);
 
         return $this->render('backoffice/prepare_elimination/index.html.twig', [
             'controller_name' => 'PrepareEliminationController',

--- a/src/Controller/Backoffice/PrepareEliminationController.php
+++ b/src/Controller/Backoffice/PrepareEliminationController.php
@@ -67,4 +67,24 @@ final class PrepareEliminationController extends AbstractController
             'elimination' => $elimination,
         ]);
     }
+
+    #[IsCsrfTokenValid('delete_elimination')]
+    #[IsGranted(SeasonVoter::DELETE, 'elimination')]
+    #[Route(
+        '/backoffice/elimination/{elimination}/delete',
+        name: 'tvdt_prepare_elimination_delete',
+        requirements: ['elimination' => Requirement::UUID],
+        methods: ['POST'],
+    )]
+    public function deleteElimination(Elimination $elimination): RedirectResponse
+    {
+        $quiz = $elimination->quiz;
+
+        $this->em->remove($elimination);
+        $this->em->flush();
+
+        $this->addFlash(FlashType::Success, 'Elimination deleted');
+
+        return $this->redirectToRoute('tvdt_backoffice_quiz', ['seasonCode' => $quiz->season->seasonCode, 'quiz' => $quiz->id]);
+    }
 }

--- a/src/Controller/Backoffice/QuizController.php
+++ b/src/Controller/Backoffice/QuizController.php
@@ -147,6 +147,11 @@ class QuizController extends AbstractController
     )]
     public function candidates_question(Season $season, Quiz $quiz, Question $question): Response
     {
+        if (false === $season->quizzes->contains($quiz)
+            || false === $quiz->questions->contains($question)) {
+            throw new BadRequestHttpException('Invalid quiz or question');
+        }
+
         // Eager-load this question's answers + candidates in one query to avoid an N+1
         // when the template checks `answer.candidates.contains(candidate)` per answer/candidate pair.
         $fetchedQuestion = $this->questionRepository->fetchWithAnswerCandidates($question->id);

--- a/src/Controller/Backoffice/QuizController.php
+++ b/src/Controller/Backoffice/QuizController.php
@@ -26,6 +26,7 @@ use Tvdt\Entity\Season;
 use Tvdt\Enum\FlashType;
 use Tvdt\Exception\ErrorClearingQuizException;
 use Tvdt\Repository\GivenAnswerRepository;
+use Tvdt\Repository\QuestionRepository;
 use Tvdt\Repository\QuizCandidateRepository;
 use Tvdt\Repository\QuizRepository;
 use Tvdt\Security\Voter\SeasonVoter;
@@ -39,6 +40,7 @@ class QuizController extends AbstractController
         private readonly TranslatorInterface $translator,
         private readonly QuizCandidateRepository $quizCandidateRepository,
         private readonly GivenAnswerRepository $givenAnswerRepository,
+        private readonly QuestionRepository $questionRepository,
         private readonly EntityManagerInterface $em,
     ) {}
 
@@ -63,13 +65,10 @@ class QuizController extends AbstractController
     {
         $fetchedQuiz = $this->quizRepository->fetchWithQuestionsAndCandidates($quiz->id);
 
-        $candidateData = $this->buildCandidateData($season, $quiz, $fetchedQuiz->candidateData);
-
         return $this->render('backoffice/quiz.html.twig', [
             'season' => $season,
             'quiz' => $fetchedQuiz,
             'questionErrors' => $fetchedQuiz->getQuestionErrors(),
-            'candidateData' => $candidateData,
             'activeTab' => 'overview',
             'template' => 'backoffice/quiz/tab_overview.html.twig',
         ]);
@@ -148,26 +147,15 @@ class QuizController extends AbstractController
     )]
     public function candidates_question(Season $season, Quiz $quiz, Question $question): Response
     {
-        // Eager-load answers' candidates in one query to avoid an N+1 when the
-        // template checks `answer.candidates.contains(candidate)` per answer/candidate pair.
-        $fetchedQuiz = $this->quizRepository->fetchWithQuestionsAndCandidates($quiz->id);
-
-        $fetchedQuestion = null;
-        foreach ($fetchedQuiz->questions as $candidateQuestion) {
-            if ($candidateQuestion->id->equals($question->id)) {
-                $fetchedQuestion = $candidateQuestion;
-
-                break;
-            }
-        }
-
-        \assert($fetchedQuestion instanceof Question);
+        // Eager-load this question's answers + candidates in one query to avoid an N+1
+        // when the template checks `answer.candidates.contains(candidate)` per answer/candidate pair.
+        $fetchedQuestion = $this->questionRepository->fetchWithAnswerCandidates($question->id);
 
         return $this->render('backoffice/quiz.html.twig', [
             'season' => $season,
             'quiz' => $quiz,
             'question' => $fetchedQuestion,
-            'candidates' => $fetchedQuiz->season->candidates,
+            'candidates' => $season->candidates,
             'activeTab' => 'answers',
             'template' => 'backoffice/quiz/tab_candidates.html.twig',
         ]);

--- a/src/Controller/Backoffice/QuizController.php
+++ b/src/Controller/Backoffice/QuizController.php
@@ -349,38 +349,38 @@ class QuizController extends AbstractController
         return $this->redirectToRoute('tvdt_backoffice_season', ['seasonCode' => $quiz->season->seasonCode]);
     }
 
-    #[IsCsrfTokenValid('candidate_correction')]
+    #[IsCsrfTokenValid('candidate_result')]
     #[IsGranted(SeasonVoter::EDIT, subject: 'quiz')]
     #[Route(
-        '/backoffice/quiz/{quiz}/candidate/{candidate}/modify_correction',
-        name: 'tvdt_backoffice_modify_correction',
+        '/backoffice/quiz/{quiz}/candidate/{candidate}/modify_result',
+        name: 'tvdt_backoffice_modify_result',
         requirements: ['quiz' => Requirement::UUID, 'candidate' => Requirement::UUID],
         methods: ['POST'],
     )]
-    public function modifyCorrection(Quiz $quiz, Candidate $candidate, Request $request): RedirectResponse
+    public function modifyResult(Quiz $quiz, Candidate $candidate, Request $request): RedirectResponse
     {
         $corrections = (float) $request->request->get('corrections');
-
-        $this->quizCandidateRepository->setCorrectionsForCandidate($quiz, $candidate, $corrections);
-
-        return $this->redirectToRoute('tvdt_backoffice_quiz', ['seasonCode' => $quiz->season->seasonCode, 'quiz' => $quiz->id]);
-    }
-
-    #[IsCsrfTokenValid('candidate_penalty')]
-    #[IsGranted(SeasonVoter::EDIT, subject: 'quiz')]
-    #[Route(
-        '/backoffice/quiz/{quiz}/candidate/{candidate}/modify_penalty',
-        name: 'tvdt_backoffice_modify_penalty',
-        requirements: ['quiz' => Requirement::UUID, 'candidate' => Requirement::UUID],
-        methods: ['POST'],
-    )]
-    public function modifyPenalty(Quiz $quiz, Candidate $candidate, Request $request): RedirectResponse
-    {
         $penalty = (int) $request->request->get('penalty');
 
-        $this->quizCandidateRepository->setPenaltyForCandidate($quiz, $candidate, $penalty);
+        $this->quizCandidateRepository->setResultForCandidate($quiz, $candidate, $corrections, $penalty);
 
-        return $this->redirectToRoute('tvdt_backoffice_quiz', ['seasonCode' => $quiz->season->seasonCode, 'quiz' => $quiz->id]);
+        return $this->redirectToRoute('tvdt_backoffice_quiz_result', ['seasonCode' => $quiz->season->seasonCode, 'quiz' => $quiz->id]);
+    }
+
+    #[IsCsrfTokenValid('quiz_dropouts')]
+    #[IsGranted(SeasonVoter::EDIT, subject: 'quiz')]
+    #[Route(
+        '/backoffice/quiz/{quiz}/modify_dropouts',
+        name: 'tvdt_backoffice_modify_dropouts',
+        requirements: ['quiz' => Requirement::UUID],
+        methods: ['POST'],
+    )]
+    public function modifyDropouts(Quiz $quiz, Request $request): RedirectResponse
+    {
+        $quiz->dropouts = max(1, $request->request->getInt('dropouts'));
+        $this->em->flush();
+
+        return $this->redirectToRoute('tvdt_backoffice_quiz_result', ['seasonCode' => $quiz->season->seasonCode, 'quiz' => $quiz->id]);
     }
 
     #[IsCsrfTokenValid('toggle_candidate')]

--- a/src/Controller/EliminationController.php
+++ b/src/Controller/EliminationController.php
@@ -17,6 +17,7 @@ use Tvdt\Entity\Candidate;
 use Tvdt\Entity\Elimination;
 use Tvdt\Entity\EliminationScreenView;
 use Tvdt\Enum\FlashType;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Form\EliminationEnterNameType;
 use Tvdt\Helpers\Base64;
 use Tvdt\Repository\CandidateRepository;
@@ -69,7 +70,7 @@ final class EliminationController extends AbstractController
 
         $screenColour = $elimination->getScreenColour($candidate->name);
 
-        if (null === $screenColour) {
+        if (!$screenColour instanceof ScreenColour) {
             $this->addFlash(FlashType::Warning, $this->translator->trans('Could not find candidate with name {name} in elimination.', ['name' => $candidate->name]));
 
             return $this->redirectToRoute('tvdt_elimination', ['elimination' => $elimination->id]);
@@ -80,7 +81,7 @@ final class EliminationController extends AbstractController
 
         return $this->render('quiz/elimination/candidate.html.twig', [
             'candidate' => $candidate,
-            'colour' => $screenColour,
+            'colour' => $screenColour->value,
         ]);
     }
 }

--- a/src/Controller/EliminationController.php
+++ b/src/Controller/EliminationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tvdt\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,6 +15,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tvdt\Entity\Candidate;
 use Tvdt\Entity\Elimination;
+use Tvdt\Entity\EliminationScreenView;
 use Tvdt\Enum\FlashType;
 use Tvdt\Form\EliminationEnterNameType;
 use Tvdt\Helpers\Base64;
@@ -26,7 +28,11 @@ use function Symfony\Component\Translation\t;
 #[IsGranted('IS_AUTHENTICATED')]
 final class EliminationController extends AbstractController
 {
-    public function __construct(private readonly TranslatorInterface $translator, private readonly CandidateRepository $candidateRepository) {}
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly CandidateRepository $candidateRepository,
+        private readonly EntityManagerInterface $em,
+    ) {}
 
     #[IsGranted(SeasonVoter::ELIMINATION, 'elimination')]
     #[Route('/elimination/{elimination}', name: 'tvdt_elimination', requirements: ['elimination' => Requirement::UUID])]
@@ -68,6 +74,9 @@ final class EliminationController extends AbstractController
 
             return $this->redirectToRoute('tvdt_elimination', ['elimination' => $elimination->id]);
         }
+
+        $this->em->persist(new EliminationScreenView($elimination, $candidate, $screenColour));
+        $this->em->flush();
 
         return $this->render('quiz/elimination/candidate.html.twig', [
             'candidate' => $candidate,

--- a/src/Controller/QuizController.php
+++ b/src/Controller/QuizController.php
@@ -6,6 +6,7 @@ namespace Tvdt\Controller;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -33,7 +34,7 @@ use Tvdt\Repository\SeasonRepository;
 #[AsController]
 final class QuizController extends AbstractController
 {
-    public function __construct(private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly SeasonRepository $seasonRepository, private readonly CandidateRepository $candidateRepository, private readonly QuestionRepository $questionRepository, private readonly AnswerRepository $answerRepository, private readonly QuizCandidateRepository $quizCandidateRepository, private readonly RateLimiterFactoryInterface $seasonCodeLimiter) {}
+    public function __construct(private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly SeasonRepository $seasonRepository, private readonly CandidateRepository $candidateRepository, private readonly QuestionRepository $questionRepository, private readonly AnswerRepository $answerRepository, private readonly QuizCandidateRepository $quizCandidateRepository, #[Target('season_code')] private readonly RateLimiterFactoryInterface $seasonCodeLimiter) {}
 
     #[Route(path: '/', name: 'tvdt_quiz_select_season', methods: ['GET', 'POST'])]
     public function selectSeason(Request $request): Response

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -6,11 +6,20 @@ namespace Tvdt\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
+use Safe\DateTimeImmutable;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Tvdt\Entity\Answer;
+use Tvdt\Entity\GivenAnswer;
+use Tvdt\Entity\Quiz;
+use Tvdt\Entity\QuizCandidate;
+use Tvdt\Entity\Season;
+use Tvdt\Entity\SeasonSettings;
 use Tvdt\Entity\User;
 
-final class DevFixtures extends Fixture implements FixtureGroupInterface
+final class DevFixtures extends Fixture implements FixtureGroupInterface, DependentFixtureInterface
 {
     public function __construct(
         private readonly UserPasswordHasherInterface $passwordHasher,
@@ -21,8 +30,15 @@ final class DevFixtures extends Fixture implements FixtureGroupInterface
         return ['dev'];
     }
 
+    public function getDependencies(): array
+    {
+        return [KrtekFixtures::class];
+    }
+
     public function load(ObjectManager $manager): void
     {
+        \assert($manager instanceof EntityManagerInterface);
+
         $user = new User();
         $user->email = 'admin@tijdvoordetest.nl';
         $user->password = $this->passwordHasher->hashPassword($user, '12345678');
@@ -30,6 +46,70 @@ final class DevFixtures extends Fixture implements FixtureGroupInterface
 
         $manager->persist($user);
 
+        $krtekOwner = new User();
+        $krtekOwner->email = 'krtek@tijdvoordetest.nl';
+        $krtekOwner->password = $this->passwordHasher->hashPassword($krtekOwner, '12345678');
+
+        $manager->persist($krtekOwner);
+
+        $this->setUpKrtekDemoState($manager, $krtekOwner);
+
         $manager->flush();
+    }
+
+    /**
+     * Overlays a more realistic demo state on top of KrtekFixtures for local browsing: quiz 1 fully played out and
+     * finalized, quiz 2 finalized and active, answer confirmation disabled. Kept out of KrtekFixtures itself since
+     * that fixture is also loaded for the 'test' group, and a lot of tests rely on its original state (an
+     * unstarted, assignable quiz to finalize/activate, an active quiz with no given answers yet, etc).
+     */
+    private function setUpKrtekDemoState(EntityManagerInterface $manager, User $owner): void
+    {
+        $season = $this->getReference(KrtekFixtures::KRTEK_SEASON, Season::class);
+        $quiz1 = $this->getReference(KrtekFixtures::KRTEK_QUIZ_1, Quiz::class);
+        $quiz2 = $this->getReference(KrtekFixtures::KRTEK_QUIZ_2, Quiz::class);
+
+        $season->addOwner($owner);
+
+        $this->fillInQuiz($manager, $quiz1);
+
+        $quiz2->finalizedAt = new DateTimeImmutable();
+        $season->activeQuiz = $quiz2;
+
+        \assert($season->settings instanceof SeasonSettings);
+        $season->settings->confirmAnswers = false;
+    }
+
+    /**
+     * Has every candidate in the quiz's season fill in the quiz with a random answer to every question, spreading
+     * the given answers' timestamps over a random 2-6 minute span per candidate so the results list (which is
+     * ordered by score and then by time taken) shows realistic variation instead of every candidate finishing
+     * instantly.
+     */
+    private function fillInQuiz(EntityManagerInterface $manager, Quiz $quiz): void
+    {
+        $givenAnswerMetadata = $manager->getClassMetadata(GivenAnswer::class);
+        $questionCount = $quiz->questions->count();
+
+        foreach ($quiz->season->candidates as $candidate) {
+            $started = new DateTimeImmutable();
+            $quizCandidate = new QuizCandidate($quiz, $candidate);
+            $quizCandidate->started = $started;
+            $manager->persist($quizCandidate);
+
+            $durationSeconds = random_int(120, 360);
+
+            foreach ($quiz->questions as $index => $question) {
+                $answers = $question->answers;
+                $randomAnswer = $answers->get(random_int(0, $answers->count() - 1));
+                \assert($randomAnswer instanceof Answer);
+
+                $givenAnswer = new GivenAnswer($candidate, $quiz, $randomAnswer);
+                $manager->persist($givenAnswer);
+
+                $offsetSeconds = (int) round($durationSeconds * ($index + 1) / $questionCount);
+                $givenAnswerMetadata->setFieldValue($givenAnswer, 'created', $started->modify(\sprintf('+%d seconds', $offsetSeconds)));
+            }
+        }
     }
 }

--- a/src/DataFixtures/KrtekFixtures.php
+++ b/src/DataFixtures/KrtekFixtures.php
@@ -67,6 +67,15 @@ final class KrtekFixtures extends Fixture implements FixtureGroupInterface
         $quiz2 = $this->createQuiz2($season);
         $season->addQuiz($quiz2);
 
+        $quiz3 = $this->createQuiz3($season);
+        $season->addQuiz($quiz3);
+
+        $quiz4 = $this->createQuiz4($season);
+        $season->addQuiz($quiz4);
+
+        $quiz5 = $this->createQuiz5($season);
+        $season->addQuiz($quiz5);
+
         \assert($season->settings instanceof SeasonSettings);
 
         $season->settings->confirmAnswers = true;
@@ -450,6 +459,519 @@ final class KrtekFixtures extends Fixture implements FixtureGroupInterface
           ->addAnswer(new Answer('Philine'))
           ->addAnswer(new Answer('Remy'))
           ->addAnswer(new Answer('Robbert'))
+          ->addAnswer(new Answer('Tom'));
+        $q->ordering = 15;
+        $quiz->addQuestion($q);
+
+        return $quiz;
+    }
+
+    private function createQuiz3(Season $season): Quiz
+    {
+        $quiz = new Quiz();
+        $quiz->name = 'Quiz 3';
+        $quiz->season = $season;
+
+        $q = new Question();
+        $q->question = 'Is de Krtek een man of een vrouw?';
+        $q->addAnswer(new Answer('Man'))
+          ->addAnswer(new Answer('Vrouw', true));
+        $q->ordering = 1;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Bij welk onderdeel zat de Krtek bij de opdracht "Blind vertrouwen"?';
+        // No answer was marked correct in the source spreadsheet for this question; "Beweging" was
+        // chosen arbitrarily on import and is not necessarily correct for the real situation.
+        $q->addAnswer(new Answer('Beweging', true))
+          ->addAnswer(new Answer('Precisie'))
+          ->addAnswer(new Answer('Oog voor Detail'))
+          ->addAnswer(new Answer('Ruimtelijk Inzicht'))
+          ->addAnswer(new Answer('Diepte'))
+          ->addAnswer(new Answer('Nattigheid'))
+          ->addAnswer(new Answer('Overzicht'));
+        $q->ordering = 2;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Snurkt de Krtek?';
+        $q->addAnswer(new Answer('Ja'))
+          ->addAnswer(new Answer('Nee', true))
+          ->addAnswer(new Answer('Nee?'));
+        $q->ordering = 3;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wat kon de Krtek bij de opdracht "Blind Vertrouwen" niet?';
+        // No answer was marked correct in the source spreadsheet for this question; "Zien" was
+        // chosen arbitrarily on import and is not necessarily correct for the real situation.
+        $q->addAnswer(new Answer('Zien', true))
+          ->addAnswer(new Answer('De handen gebruiken'));
+        $q->ordering = 4;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Heeft de Krtek vanmorgen gedoucht?';
+        // No answer was marked correct in the source spreadsheet for this question; "Ja" was
+        // chosen arbitrarily on import and is not necessarily correct for the real situation.
+        $q->addAnswer(new Answer('Ja', true))
+          ->addAnswer(new Answer('Nee'));
+        $q->ordering = 5;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'In welke ruimte keek de Krtek gisteren de video?';
+        $q->addAnswer(new Answer('In de kleine keuken', true))
+          ->addAnswer(new Answer('In de organisatie-huiskamer'));
+        $q->ordering = 6;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Welke kleur drinken dronk de Krtek bij de cupcakes?';
+        $q->addAnswer(new Answer('Kleurloos', true))
+          ->addAnswer(new Answer('Groen'))
+          ->addAnswer(new Answer('Rood'));
+        $q->ordering = 7;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Hoe oud is de Krtek?';
+        $q->addAnswer(new Answer('20'))
+          ->addAnswer(new Answer('22'))
+          ->addAnswer(new Answer('23'))
+          ->addAnswer(new Answer('25'))
+          ->addAnswer(new Answer('26'))
+          ->addAnswer(new Answer('27'))
+          ->addAnswer(new Answer('29', true))
+          ->addAnswer(new Answer('30'))
+          ->addAnswer(new Answer('31'))
+          ->addAnswer(new Answer('32'))
+          ->addAnswer(new Answer('33'));
+        $q->ordering = 8;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Bespeelt de Krtek een muziekinstrument en zo ja, welke?';
+        $q->addAnswer(new Answer('Ja, piano'))
+          ->addAnswer(new Answer('Ja, gitaar'))
+          ->addAnswer(new Answer('Ja, gitaar en een beetje mondharmonica'))
+          ->addAnswer(new Answer('Ja, een beetje ukulele'))
+          ->addAnswer(new Answer('Nee', true));
+        $q->ordering = 9;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Hoeveel geld is er verdiend met het onderdeel van de Krtek bij de opdracht "Blind Vertrouwen"?';
+        // No answer was marked correct in the source spreadsheet for this question; "€ 0,-" was
+        // chosen arbitrarily on import and is not necessarily correct for the real situation.
+        $q->addAnswer(new Answer('€ 0,-', true))
+          ->addAnswer(new Answer('€ 10,-'))
+          ->addAnswer(new Answer('€ 15,-'))
+          ->addAnswer(new Answer('€ 20,-'))
+          ->addAnswer(new Answer('€ 30,-'));
+        $q->ordering = 10;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wat is de schoenmaat van de Krtek?';
+        $q->addAnswer(new Answer('37'))
+          ->addAnswer(new Answer('39'))
+          ->addAnswer(new Answer('39'))
+          ->addAnswer(new Answer('40', true))
+          ->addAnswer(new Answer('42'))
+          ->addAnswer(new Answer('42.5'))
+          ->addAnswer(new Answer('43'))
+          ->addAnswer(new Answer('46'));
+        $q->ordering = 11;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Op welk huisnummer woont de Krtek?';
+        $q->addAnswer(new Answer('12'))
+          ->addAnswer(new Answer('16'))
+          ->addAnswer(new Answer('20'))
+          ->addAnswer(new Answer('21'))
+          ->addAnswer(new Answer('51'))
+          ->addAnswer(new Answer('58-2', true))
+          ->addAnswer(new Answer('73'))
+          ->addAnswer(new Answer('350'));
+        $q->ordering = 12;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Via wie kwam de Krtek er achter dat Sinterklaas niet bestond?';
+        $q->addAnswer(new Answer('Moeder', true))
+          ->addAnswer(new Answer('Vader'))
+          ->addAnswer(new Answer('Beide ouders'))
+          ->addAnswer(new Answer('Vriendin'))
+          ->addAnswer(new Answer('De Krtek heeft geen idee'))
+          ->addAnswer(new Answer('De Krtek vertelde het zelf aan zijn ouders'));
+        $q->ordering = 13;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Heeft de Krtek gisteravond gebiecht?';
+        $q->addAnswer(new Answer('Ja'))
+          ->addAnswer(new Answer('Nee', true));
+        $q->ordering = 14;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wie is de Krtek?';
+        $q->addAnswer(new Answer('Claudia', true))
+          ->addAnswer(new Answer('Eelco'))
+          ->addAnswer(new Answer('Elise'))
+          ->addAnswer(new Answer('Gert-Jan'))
+          ->addAnswer(new Answer('Iris'))
+          ->addAnswer(new Answer('Jari'))
+          ->addAnswer(new Answer('Lara'))
+          ->addAnswer(new Answer('Lotte'))
+          ->addAnswer(new Answer('Myrthe'))
+          ->addAnswer(new Answer('Philine'))
+          ->addAnswer(new Answer('Remy'))
+          ->addAnswer(new Answer('Robbert'))
+          ->addAnswer(new Answer('Tom'));
+        $q->ordering = 15;
+        $quiz->addQuestion($q);
+
+        return $quiz;
+    }
+
+    private function createQuiz4(Season $season): Quiz
+    {
+        $quiz = new Quiz();
+        $quiz->name = 'Quiz 4';
+        $quiz->season = $season;
+
+        $q = new Question();
+        $q->question = 'Is de Krtek een man of een vrouw?';
+        $q->addAnswer(new Answer('Man'))
+          ->addAnswer(new Answer('Vrouw', true));
+        $q->ordering = 1;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Waar zat de Krtek vanmiddag aan tafel tijdens de lunch?';
+        $q->addAnswer(new Answer('Aan de kant van de buitenmuur'))
+          ->addAnswer(new Answer('Aan de kant van de ingang', true));
+        $q->ordering = 2;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wat dronk de Krtek tijdens de lunch?';
+        $q->addAnswer(new Answer('Thee'))
+          ->addAnswer(new Answer('Chocomel'))
+          ->addAnswer(new Answer('Bier'))
+          ->addAnswer(new Answer('Appelsap'))
+          ->addAnswer(new Answer('Ice tea green'))
+          ->addAnswer(new Answer('Pepsi', true))
+          ->addAnswer(new Answer('Pepsi max'))
+          ->addAnswer(new Answer('Fristi'))
+          ->addAnswer(new Answer('Cappuccino'))
+          ->addAnswer(new Answer("Jus d'orange"));
+        $q->ordering = 3;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Is er iets dat de Krtek graag viert?';
+        $q->addAnswer(new Answer('Nee'))
+          ->addAnswer(new Answer("Nee, gezellige avonden hoeven voor de Krtek niet samen te vallen met 'bijzondere' momenten."))
+          ->addAnswer(new Answer('Sinterklaas'))
+          ->addAnswer(new Answer('Kerst'))
+          ->addAnswer(new Answer('Oud en Nieuw'))
+          ->addAnswer(new Answer('Gay Pride', true))
+          ->addAnswer(new Answer('Bevrijdingsdag, want dat vier ik meteen mijn verjaardag'))
+          ->addAnswer(new Answer('Het leven'));
+        $q->ordering = 4;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Heeft de Krtek nog opa’s/oma’s? Zo ja, wat zijn de namen?';
+        $q->addAnswer(new Answer('Ja, Oma Toos', true))
+          ->addAnswer(new Answer('Ja, Opa Piet en Oma Door'))
+          ->addAnswer(new Answer('Ja, Oma Greet, Opa Wim en Oma Bep'))
+          ->addAnswer(new Answer('Ja, Opa Cor (Eigenlijk Cornelis), Oma Grada en Oma Willy'))
+          ->addAnswer(new Answer('Nee'));
+        $q->ordering = 5;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wat is het eerste dat de Krtek zou doen als hij een dag van geslacht veranderd?';
+        $q->addAnswer(new Answer('Plassen'))
+          ->addAnswer(new Answer('Wildplassen', true))
+          ->addAnswer(new Answer('Staand plassen'))
+          ->addAnswer(new Answer('in de spiegel kijken'))
+          ->addAnswer(new Answer('Een geslachtelijk onderzoek'))
+          ->addAnswer(new Answer('Heel de dag voor de spiegel staan'))
+          ->addAnswer(new Answer('Testen hoe goed een beha werkt als telefoonhouder'))
+          ->addAnswer(new Answer('Een dag werken en kijken hoe de wereld je anders behandeld'));
+        $q->ordering = 6;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Heeft de Krtek vanmorgen een geheim bericht gevonden op het toilet?';
+        $q->addAnswer(new Answer('Ja'))
+          ->addAnswer(new Answer('Nee', true));
+        $q->ordering = 7;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Heeft de Krtek gebeld met de ontvoerde kandidaten tijdens de opdracht Happen, Trappen en Ontsnappen?';
+        // No answer was marked correct in the source spreadsheet for this question; "Ja" was
+        // chosen arbitrarily on import and is not necessarily correct for the real situation.
+        $q->addAnswer(new Answer('Ja', true))
+          ->addAnswer(new Answer('Nee'))
+          ->addAnswer(new Answer('De Krtek was zelf één van de ontvoerde kandidaten'));
+        $q->ordering = 8;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'In welke groep zat de Krtek tijdens de opdracht Happen, Trappen en Ontsnappen?';
+        $q->addAnswer(new Answer('De langzame fietsgroep'))
+          ->addAnswer(new Answer('De gemiddelde fietsgroep', true))
+          ->addAnswer(new Answer('De snelle fietsgroep'))
+          ->addAnswer(new Answer('De ontvoerde kandidaten'));
+        $q->ordering = 9;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Als hoeveelste was het groepje van de Krtek op de Grebbeberg?';
+        $q->addAnswer(new Answer('Als eerste'))
+          ->addAnswer(new Answer('Als tweede'))
+          ->addAnswer(new Answer('Het groepje van de Krtek kwam niet bij de Grebbeberg', true));
+        $q->ordering = 10;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wat is het favoriete muzieknummer allertijden van de Krtek?';
+        $q->addAnswer(new Answer('Taylor Swift - Long Live'))
+          ->addAnswer(new Answer('Kiefer Sutherland - Something you love'))
+          ->addAnswer(new Answer('Yes-R - Hey Schatje'))
+          ->addAnswer(new Answer('Bronsku Beat - Smalltown Boy', true))
+          ->addAnswer(new Answer('Queen - Bohemian Rhapsody'))
+          ->addAnswer(new Answer('Imagine Dragons - Birds'))
+          ->addAnswer(new Answer('Chipz - 1001 Arabian Nights'))
+          ->addAnswer(new Answer('Nightwish - Ghost Love Score'));
+        $q->ordering = 11;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Aan welk gerecht heeft de Krtek de grootste bijdrage geleverd bij het koken?';
+        $q->addAnswer(new Answer('Voorgerecht'))
+          ->addAnswer(new Answer('Hoodgerecht', true))
+          ->addAnswer(new Answer('Nagerecht'))
+          ->addAnswer(new Answer('Geen bijdrage'));
+        $q->ordering = 12;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Heeft de Krtek de fruitliedjesopdracht op de juiste GPS-locatie uitgevoerd?';
+        $q->addAnswer(new Answer('Ja', true))
+          ->addAnswer(new Answer('Nee'))
+          ->addAnswer(new Answer('De Krtek heeft deze opdracht niet uitgevoerd'));
+        $q->ordering = 13;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Als hoeveelste ging de Krtek vanmiddag biechten?';
+        $q->addAnswer(new Answer('Eerste'))
+          ->addAnswer(new Answer('Tweede'))
+          ->addAnswer(new Answer('Derde'))
+          ->addAnswer(new Answer('Vierde', true))
+          ->addAnswer(new Answer('Vijfde'))
+          ->addAnswer(new Answer('Zesde'))
+          ->addAnswer(new Answer('Zevende'))
+          ->addAnswer(new Answer('Achtste'))
+          ->addAnswer(new Answer('Negende'))
+          ->addAnswer(new Answer('Tiende'))
+          ->addAnswer(new Answer('Elfde'))
+          ->addAnswer(new Answer('Twaalfde'))
+          ->addAnswer(new Answer('Dertiende'));
+        $q->ordering = 14;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wie is de Krtek?';
+        $q->addAnswer(new Answer('Claudia', true))
+          ->addAnswer(new Answer('Eelco'))
+          ->addAnswer(new Answer('Elise'))
+          ->addAnswer(new Answer('Gert-Jan'))
+          ->addAnswer(new Answer('Iris'))
+          ->addAnswer(new Answer('Jari'))
+          ->addAnswer(new Answer('Lara'))
+          ->addAnswer(new Answer('Lotte'))
+          ->addAnswer(new Answer('Myrthe'))
+          ->addAnswer(new Answer('Philine'))
+          ->addAnswer(new Answer('Remy'))
+          ->addAnswer(new Answer('Robbert'))
+          ->addAnswer(new Answer('Tom'));
+        $q->ordering = 15;
+        $quiz->addQuestion($q);
+
+        return $quiz;
+    }
+
+    private function createQuiz5(Season $season): Quiz
+    {
+        $quiz = new Quiz();
+        $quiz->name = 'Quiz 5';
+        $quiz->season = $season;
+
+        $q = new Question();
+        $q->question = 'Is de Krtek een man of een vrouw?';
+        $q->addAnswer(new Answer('Man'))
+          ->addAnswer(new Answer('Vrouw', true));
+        $q->ordering = 1;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Bij welk team hoorde de Krtek tijdens de opdracht "Pyjamaparty"?';
+        $q->addAnswer(new Answer('Team Groen'))
+          ->addAnswer(new Answer('Team Rood', true));
+        $q->ordering = 2;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = "Is de Krtek een 80's, 90's of 00's -kid?";
+        $q->addAnswer(new Answer("80's"))
+          ->addAnswer(new Answer("90's", true))
+          ->addAnswer(new Answer("00's"));
+        $q->ordering = 3;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wat is de lievelingsgeur van de Krtek?';
+        $q->addAnswer(new Answer('Banaan'))
+          ->addAnswer(new Answer('Blauw'))
+          ->addAnswer(new Answer('De zee'))
+          ->addAnswer(new Answer('Verse appeltaart'))
+          ->addAnswer(new Answer('Glow van JLO'))
+          ->addAnswer(new Answer('Lavendel'))
+          ->addAnswer(new Answer('Vanille', true));
+        $q->ordering = 4;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Aan welke tafel zat de Krtek bij het avondeten?';
+        $q->addAnswer(new Answer('Aan de tafel het dichtst bij het terras'))
+          ->addAnswer(new Answer('Aan de tafel in het midden'))
+          ->addAnswer(new Answer('Aan de tafel het dichtst bij het fornuis', true));
+        $q->ordering = 5;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Heeft de Krtek iets in een wijnglas gegoten bij de poging om een rood bruisend drankje te maken?';
+        $q->addAnswer(new Answer('Ja'))
+          ->addAnswer(new Answer('Nee', true));
+        $q->ordering = 6;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wie was de kamergenoot van de Krtek tijdens de trust Nobody-Reis in Tsjechië?';
+        $q->addAnswer(new Answer('Daniëlle'))
+          ->addAnswer(new Answer('Edwin'))
+          ->addAnswer(new Answer('Eelco'))
+          ->addAnswer(new Answer('Elise'))
+          ->addAnswer(new Answer('Gerry'))
+          ->addAnswer(new Answer('Gert-Jan'))
+          ->addAnswer(new Answer('Joelle'))
+          ->addAnswer(new Answer('Lara'))
+          ->addAnswer(new Answer('Lotte'))
+          ->addAnswer(new Answer('Myrthe'))
+          ->addAnswer(new Answer('Niemand', true));
+        $q->ordering = 7;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Met welke bekende persoon zou de Krtek wel eens een beschuitje willen eten?';
+        $q->addAnswer(new Answer('Art Rooijakkers'))
+          ->addAnswer(new Answer('Emma Watson', true))
+          ->addAnswer(new Answer('India de Beaufort'))
+          ->addAnswer(new Answer('Jennifer Aniston'))
+          ->addAnswer(new Answer('Lewis Hamilton'))
+          ->addAnswer(new Answer('Sara Bereilles'));
+        $q->ordering = 8;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Heb de Krtek wel eens iets gestolen? Zo ja, wat?';
+        $q->addAnswer(new Answer('Nee'))
+          ->addAnswer(new Answer('Ja, snoep'))
+          ->addAnswer(new Answer('Ja, een stripboek', true))
+          ->addAnswer(new Answer('Hooguit wat koeken uit de keukenkastjes'))
+          ->addAnswer(new Answer('Ja, meermaals onbewust niet gescande boodschappen, met opzet een een sleutelhanger in Disneyland Parijs, een Gamecube spel van een klasgenoot en pins in de Super Panda Circus'));
+        $q->ordering = 9;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wat dronk de Krtek tijdens de opdracht "Pyjamaparty"?';
+        $q->addAnswer(new Answer('Water', true))
+          ->addAnswer(new Answer('Chocomel'))
+          ->addAnswer(new Answer('Bier'))
+          ->addAnswer(new Answer('Fanta'))
+          ->addAnswer(new Answer('Cola'))
+          ->addAnswer(new Answer('Cola zero'))
+          ->addAnswer(new Answer('Rode wijn'))
+          ->addAnswer(new Answer('Witte wijn'));
+        $q->ordering = 10;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wat is het lievelingsdrankje van de Krtek?';
+        $q->addAnswer(new Answer('Cola zero'))
+          ->addAnswer(new Answer('Dubbelfris Appel/Perzik'))
+          ->addAnswer(new Answer('IPA bier'))
+          ->addAnswer(new Answer('Lindemans biertje'))
+          ->addAnswer(new Answer('Moijto'))
+          ->addAnswer(new Answer('Rode wijn'))
+          ->addAnswer(new Answer('Sgroppino', true))
+          ->addAnswer(new Answer('Virgin mojito'));
+        $q->ordering = 11;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'In welke huiskamer zat de Krtek tijdens het kijken van de aflevering in de opdracht "Pyjamaparty"?';
+        $q->addAnswer(new Answer('Bellefleur', true))
+          ->addAnswer(new Answer('Juttepeer'));
+        $q->ordering = 12;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Waar zat de Krtek op tijdens de opdracht "Pyjamaparty"?';
+        $q->addAnswer(new Answer('Een stoel'))
+          ->addAnswer(new Answer('Een bank', true))
+          ->addAnswer(new Answer('Een krukje'))
+          ->addAnswer(new Answer('De grond'));
+        $q->ordering = 13;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Welke bekende persoon kan de Krtek echt niet uitstaan?';
+        $q->addAnswer(new Answer('Chantal Janzen', true))
+          ->addAnswer(new Answer('Gordon'))
+          ->addAnswer(new Answer('Linda de Mol'))
+          ->addAnswer(new Answer('Maurice de Hond'))
+          ->addAnswer(new Answer('Sjaak Zwart'))
+          ->addAnswer(new Answer('Thierry Baudet'));
+        $q->ordering = 14;
+        $quiz->addQuestion($q);
+
+        $q = new Question();
+        $q->question = 'Wie is de Krtek?';
+        $q->addAnswer(new Answer('Claudia', true))
+          ->addAnswer(new Answer('Eelco'))
+          ->addAnswer(new Answer('Elise'))
+          ->addAnswer(new Answer('Gert-Jan'))
+          ->addAnswer(new Answer('Iris'))
+          ->addAnswer(new Answer('Jari'))
+          ->addAnswer(new Answer('Lara'))
+          ->addAnswer(new Answer('Lotte'))
+          ->addAnswer(new Answer('Myrthe'))
+          ->addAnswer(new Answer('Philine'))
+          ->addAnswer(new Answer('Remy'))
+          ->addAnswer(new Answer('Rianne'))
+          ->addAnswer(new Answer('Robbert'))
+          ->addAnswer(new Answer('Rowan'))
           ->addAnswer(new Answer('Tom'));
         $q->ordering = 15;
         $quiz->addQuestion($q);

--- a/src/DataFixtures/KrtekFixtures.php
+++ b/src/DataFixtures/KrtekFixtures.php
@@ -82,6 +82,7 @@ final class KrtekFixtures extends Fixture implements FixtureGroupInterface
         $season->settings->showNumbers = true;
 
         $this->createQuestionBank($season, $quiz2);
+        $this->bindQuizQuestionsToBank($season);
 
         $manager->flush();
 
@@ -102,7 +103,7 @@ final class KrtekFixtures extends Fixture implements FixtureGroupInterface
         $season->addQuestionLabel($finale);
 
         $reusable = new BankQuestion();
-        $reusable->question = 'Wie is de Krtek?';
+        $reusable->question = 'Wat is de bijnaam van de Krtek?';
         $reusable->reusable = true;
         $reusable->addLabel($finale);
         $reusable->addAnswer(new BankAnswer('Claudia', true));
@@ -133,6 +134,41 @@ final class KrtekFixtures extends Fixture implements FixtureGroupInterface
         $this->addReference(self::BANK_QUESTION_REUSABLE, $reusable);
         $this->addReference(self::BANK_QUESTION_USED, $used);
         $this->addReference(self::BANK_QUESTION_UNUSED, $unused);
+    }
+
+    /**
+     * Mirrors every quiz question into the question bank, so the bank reflects what was actually
+     * asked. A question text reused across quizzes (e.g. the recurring "man of vrouw"/"wie is de
+     * Krtek" questions) becomes a single reusable bank question with one usage per quiz it appears
+     * in, instead of a separate bank question per occurrence.
+     */
+    private function bindQuizQuestionsToBank(Season $season): void
+    {
+        /** @var array<string, BankQuestion> $bankQuestionsByText */
+        $bankQuestionsByText = [];
+
+        foreach ($season->quizzes as $quiz) {
+            foreach ($quiz->questions as $question) {
+                $bankQuestion = $bankQuestionsByText[$question->question] ?? null;
+
+                if (null === $bankQuestion) {
+                    $bankQuestion = new BankQuestion();
+                    $bankQuestion->question = $question->question;
+                    foreach ($question->answers as $answer) {
+                        $bankQuestion->addAnswer(new BankAnswer($answer->text, $answer->isRightAnswer));
+                    }
+
+                    $season->addBankQuestion($bankQuestion);
+                    $bankQuestionsByText[$question->question] = $bankQuestion;
+                } else {
+                    $bankQuestion->reusable = true;
+                }
+
+                $usage = new BankQuestionUsage($bankQuestion, $quiz);
+                $usage->question = $question;
+                $bankQuestion->addUsage($usage);
+            }
+        }
     }
 
     private function createQuiz1(Season $season): Quiz

--- a/src/Entity/Elimination.php
+++ b/src/Entity/Elimination.php
@@ -14,6 +14,7 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\Uid\Uuid;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Repository\EliminationRepository;
 
 #[Gedmo\SoftDeleteable]
@@ -23,17 +24,13 @@ class Elimination
     use SoftDeleteableEntity;
     use TimestampableEntity;
 
-    public const string SCREEN_GREEN = 'green';
-
-    public const string SCREEN_RED = 'red';
-
     #[ORM\Column(type: UuidType::NAME, unique: true)]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\Id]
     public private(set) Uuid $id;
 
-    /** @var array<string, mixed> */
+    /** @var array<string, string> */
     #[ORM\Column(type: Types::JSONB)]
     public array $data = [];
 
@@ -60,20 +57,21 @@ class Elimination
     {
         foreach (array_keys($this->data) as $name) {
             $newColour = $inputBag->get('colour-'.mb_strtolower($name));
-            if (\is_string($newColour)) {
-                $this->data[$name] = $inputBag->get('colour-'.mb_strtolower($name));
+            $screenColour = \is_string($newColour) ? ScreenColour::tryFrom($newColour) : null;
+            if ($screenColour instanceof ScreenColour) {
+                $this->data[$name] = $screenColour->value;
             }
         }
 
         return $this;
     }
 
-    public function getScreenColour(?string $name): ?string
+    public function getScreenColour(?string $name): ?ScreenColour
     {
         if (null === $name) {
             return null;
         }
 
-        return $this->data[$name] ?? null;
+        return isset($this->data[$name]) ? ScreenColour::tryFrom($this->data[$name]) : null;
     }
 }

--- a/src/Entity/Elimination.php
+++ b/src/Entity/Elimination.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tvdt\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -35,11 +37,23 @@ class Elimination
     #[ORM\Column(type: Types::JSONB)]
     public array $data = [];
 
+    /**
+     * Ordered by id (a time-ordered UUIDv7) rather than created, since created has only second precision and
+     * screens can be shown less than a second apart.
+     *
+     * @var Collection<int, EliminationScreenView>
+     */
+    #[ORM\OneToMany(targetEntity: EliminationScreenView::class, mappedBy: 'elimination', orphanRemoval: true)]
+    #[ORM\OrderBy(['id' => 'ASC'])]
+    public private(set) Collection $screenViews;
+
     public function __construct(
         #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
         #[ORM\ManyToOne(inversedBy: 'eliminations')]
         public Quiz $quiz,
-    ) {}
+    ) {
+        $this->screenViews = new ArrayCollection();
+    }
 
     /** @param InputBag<bool|float|int|string> $inputBag */
     public function updateFromInputBag(InputBag $inputBag): self

--- a/src/Entity/EliminationScreenView.php
+++ b/src/Entity/EliminationScreenView.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Uid\Uuid;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Repository\EliminationScreenViewRepository;
 
 #[ORM\Entity(repositoryClass: EliminationScreenViewRepository::class)]
@@ -33,7 +34,7 @@ class EliminationScreenView
         #[ORM\ManyToOne]
         public Candidate $candidate,
 
-        #[ORM\Column]
-        public string $colour,
+        #[ORM\Column(enumType: ScreenColour::class)]
+        public ScreenColour $colour,
     ) {}
 }

--- a/src/Entity/EliminationScreenView.php
+++ b/src/Entity/EliminationScreenView.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\Uid\Uuid;
+use Tvdt\Repository\EliminationScreenViewRepository;
+
+#[ORM\Entity(repositoryClass: EliminationScreenViewRepository::class)]
+class EliminationScreenView
+{
+    #[ORM\Column(type: UuidType::NAME, unique: true)]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\Id]
+    public private(set) Uuid $id;
+
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: false)]
+    public private(set) \DateTimeImmutable $created;
+
+    public function __construct(
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        #[ORM\ManyToOne(inversedBy: 'screenViews')]
+        public Elimination $elimination,
+
+        #[ORM\JoinColumn(nullable: false)]
+        #[ORM\ManyToOne]
+        public Candidate $candidate,
+
+        #[ORM\Column]
+        public string $colour,
+    ) {}
+}

--- a/src/Entity/EliminationScreenView.php
+++ b/src/Entity/EliminationScreenView.php
@@ -29,7 +29,7 @@ class EliminationScreenView
         #[ORM\ManyToOne(inversedBy: 'screenViews')]
         public Elimination $elimination,
 
-        #[ORM\JoinColumn(nullable: false)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
         #[ORM\ManyToOne]
         public Candidate $candidate,
 

--- a/src/Enum/ScreenColour.php
+++ b/src/Enum/ScreenColour.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Enum;
+
+use Symfony\Component\Translation\TranslatableMessage;
+
+enum ScreenColour: string
+{
+    case Green = 'green';
+    case Red = 'red';
+
+    public function label(): TranslatableMessage
+    {
+        return match ($this) {
+            self::Green => new TranslatableMessage('Green'),
+            self::Red => new TranslatableMessage('Red'),
+        };
+    }
+}

--- a/src/Factory/EliminationFactory.php
+++ b/src/Factory/EliminationFactory.php
@@ -7,6 +7,7 @@ namespace Tvdt\Factory;
 use Doctrine\ORM\EntityManagerInterface;
 use Tvdt\Entity\Elimination;
 use Tvdt\Entity\Quiz;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Repository\QuizRepository;
 
 final readonly class EliminationFactory
@@ -26,7 +27,7 @@ final readonly class EliminationFactory
         $simpleScores = [];
 
         foreach (array_reverse($scores) as $i => $score) {
-            $simpleScores[$score->name] = $i < $quiz->dropouts ? Elimination::SCREEN_RED : Elimination::SCREEN_GREEN;
+            $simpleScores[$score->name] = ($i < $quiz->dropouts ? ScreenColour::Red : ScreenColour::Green)->value;
         }
 
         $elimination->data = $simpleScores;

--- a/src/Repository/EliminationRepository.php
+++ b/src/Repository/EliminationRepository.php
@@ -6,6 +6,7 @@ namespace Tvdt\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
 use Tvdt\Entity\Elimination;
 
 /** @extends ServiceEntityRepository<Elimination> */
@@ -14,5 +15,16 @@ class EliminationRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Elimination::class);
+    }
+
+    /** Fetch an elimination with its screen views and each view's candidate eager-loaded, to avoid an N+1 when the log table renders. */
+    public function fetchWithScreenViewCandidates(Uuid $id): Elimination
+    {
+        return $this->getEntityManager()->createQuery(<<<dql
+            select e, sv, c from Tvdt\Entity\Elimination e
+            left join e.screenViews sv
+            left join sv.candidate c
+            where e.id = :id
+            dql)->setParameter('id', $id)->getSingleResult();
     }
 }

--- a/src/Repository/EliminationScreenViewRepository.php
+++ b/src/Repository/EliminationScreenViewRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Tvdt\Entity\EliminationScreenView;
+
+/** @extends ServiceEntityRepository<EliminationScreenView> */
+class EliminationScreenViewRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, EliminationScreenView::class);
+    }
+}

--- a/src/Repository/QuestionRepository.php
+++ b/src/Repository/QuestionRepository.php
@@ -6,6 +6,7 @@ namespace Tvdt\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
 use Tvdt\Entity\Candidate;
 use Tvdt\Entity\Question;
 
@@ -15,6 +16,17 @@ class QuestionRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Question::class);
+    }
+
+    /** Fetch a single question with its answers and each answer's candidates eager-loaded. */
+    public function fetchWithAnswerCandidates(Uuid $id): Question
+    {
+        return $this->getEntityManager()->createQuery(<<<dql
+            select q, a, ac from Tvdt\Entity\Question q
+            left join q.answers a
+            left join a.candidates ac
+            where q.id = :id
+            dql)->setParameter('id', $id)->getSingleResult();
     }
 
     public function findNextQuestionForCandidate(Candidate $candidate): ?Question

--- a/src/Repository/QuizCandidateRepository.php
+++ b/src/Repository/QuizCandidateRepository.php
@@ -47,7 +47,7 @@ class QuizCandidateRepository extends ServiceEntityRepository
         return true;
     }
 
-    public function setCorrectionsForCandidate(Quiz $quiz, Candidate $candidate, float $corrections): void
+    public function setResultForCandidate(Quiz $quiz, Candidate $candidate, float $corrections, int $penalty): void
     {
         $quizCandidate = $this->findOneBy(['candidate' => $candidate, 'quiz' => $quiz]);
         if (!$quizCandidate instanceof QuizCandidate) {
@@ -55,16 +55,6 @@ class QuizCandidateRepository extends ServiceEntityRepository
         }
 
         $quizCandidate->corrections = $corrections;
-        $this->getEntityManager()->flush();
-    }
-
-    public function setPenaltyForCandidate(Quiz $quiz, Candidate $candidate, int $penalty): void
-    {
-        $quizCandidate = $this->findOneBy(['candidate' => $candidate, 'quiz' => $quiz]);
-        if (!$quizCandidate instanceof QuizCandidate) {
-            throw new \InvalidArgumentException('Quiz candidate not found');
-        }
-
         $quizCandidate->penaltySeconds = $penalty;
         $this->getEntityManager()->flush();
     }

--- a/src/Repository/QuizRepository.php
+++ b/src/Repository/QuizRepository.php
@@ -174,6 +174,7 @@ class QuizRepository extends ServiceEntityRepository
             left join qz.answers a
             left join a.candidates ac
             where q.id = :id
+            order by qz.ordering asc, a.ordering asc, a.id asc
             dql)->setParameter('id', $id)->getSingleResult();
 
         /* @var Quiz */

--- a/src/Repository/QuizRepository.php
+++ b/src/Repository/QuizRepository.php
@@ -158,19 +158,29 @@ class QuizRepository extends ServiceEntityRepository
     }
 
     /**
-     * Fetch quiz with all relations needed for error checking.
-     * This includes: questions, answers, answer candidates, and season candidates.
+     * Fetch quiz with all relations needed for error checking (questions, answers, answer
+     * candidates, and candidate data). Split into two queries: joining season.candidates into
+     * the same query as the questions/answers tree would cross-multiply two independent
+     * to-many collections into a cartesian product, which is expensive to hydrate for a quiz
+     * with many questions and candidates.
      */
     public function fetchWithQuestionsAndCandidates(Uuid $id): Quiz
     {
-        return $this->getEntityManager()->createQuery(<<<dql
-            select q, qz, a, ac, s, sc, qc from Tvdt\Entity\Quiz q
+        $em = $this->getEntityManager();
+
+        $em->createQuery(<<<dql
+            select q, qz, a, ac from Tvdt\Entity\Quiz q
             left join q.questions qz
             left join qz.answers a
             left join a.candidates ac
-            join q.season s
-            left join s.candidates sc
+            where q.id = :id
+            dql)->setParameter('id', $id)->getSingleResult();
+
+        /* @var Quiz */
+        return $em->createQuery(<<<dql
+            select q, qc, c from Tvdt\Entity\Quiz q
             left join q.candidateData qc
+            left join qc.candidate c
             where q.id = :id
             dql)->setParameter('id', $id)->getSingleResult();
     }

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -168,6 +168,10 @@ class DataExportService
         $eliminations->setTitle('Eliminations');
         $this->fillEliminationsSheet($eliminations, $quiz);
 
+        $eliminationScreenViews = $spreadsheet->createSheet();
+        $eliminationScreenViews->setTitle('Elimination screen views');
+        $this->fillEliminationScreenViewsSheet($eliminationScreenViews, $quiz);
+
         $spreadsheet->setActiveSheetIndex(0);
 
         return $spreadsheet;
@@ -314,6 +318,30 @@ class DataExportService
         }
 
         foreach ($this->columnLetters(2 + \count($candidates)) as $column) {
+            $sheet->getColumnDimension($column)->setAutoSize(true);
+        }
+    }
+
+    /** One row per screen shown during an elimination, in the order they were shown. */
+    private function fillEliminationScreenViewsSheet(Worksheet $sheet, Quiz $quiz): void
+    {
+        $sheet->fromArray(['Elimination prepared at', 'Candidate', 'Colour', 'Shown at'], null, 'A1');
+        $sheet->getStyle('1:1')->getFont()->setBold(true);
+
+        $row = 2;
+        foreach ($quiz->eliminations as $elimination) {
+            foreach ($elimination->screenViews as $screenView) {
+                $sheet->fromArray([
+                    $elimination->getCreatedAt()?->format(\DateTimeInterface::ATOM) ?? '',
+                    $screenView->candidate->name,
+                    $screenView->colour,
+                    $screenView->created->format(\DateTimeInterface::ATOM),
+                ], null, 'A'.$row);
+                ++$row;
+            }
+        }
+
+        foreach (['A', 'B', 'C', 'D'] as $column) {
             $sheet->getColumnDimension($column)->setAutoSize(true);
         }
     }

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -19,6 +19,7 @@ use Tvdt\Entity\QuestionLabel;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Helpers\FilenameSanitizer;
 use Tvdt\Helpers\FormulaInjectionSafeValueBinder;
 use Tvdt\Repository\QuizRepository;
@@ -310,7 +311,8 @@ class DataExportService
             ];
 
             foreach ($candidates as $candidate) {
-                $line[] = $elimination->getScreenColour($candidate->name) ?? '';
+                $screenColour = $elimination->getScreenColour($candidate->name);
+                $line[] = $screenColour instanceof ScreenColour ? $screenColour->value : '';
             }
 
             $sheet->fromArray($line, null, 'A'.$row);
@@ -334,7 +336,7 @@ class DataExportService
                 $sheet->fromArray([
                     $elimination->getCreatedAt()?->format(\DateTimeInterface::ATOM) ?? '',
                     $screenView->candidate->name,
-                    $screenView->colour,
+                    $screenView->colour->value,
                     $screenView->created->format(\DateTimeInterface::ATOM),
                 ], null, 'A'.$row);
                 ++$row;

--- a/templates/backoffice/prepare_elimination/index.html.twig
+++ b/templates/backoffice/prepare_elimination/index.html.twig
@@ -73,7 +73,7 @@
                         {%~ for screenView in elimination.screenViews %}
                             <tr>
                                 <td>{{ screenView.candidate.name }}</td>
-                                <td>{{ (screenView.colour == 'green' ? 'Green' : 'Red')|trans }}</td>
+                                <td>{{ screenView.colour.label|trans }}</td>
                                 <td>{{ screenView.created|format_datetime() }}</td>
                             </tr>
                         {% endfor %}

--- a/templates/backoffice/prepare_elimination/index.html.twig
+++ b/templates/backoffice/prepare_elimination/index.html.twig
@@ -12,56 +12,84 @@
 {% endblock %}
 
 {% block body %}
-    <div class="row">
-        <div class="col-12 col-md-6">
-            <form method="post">
-                <input type="hidden" name="_token" value="{{ csrf_token('prepare_elimination') }}">
-                {%~ for candidate, colour in elimination.data %}
-                    <div class="row mb-3">
-                        <label for="colour-{{ candidate|lower }}" class="col-4 col-form-label">{{ candidate }}</label>
-                        <div class="col-4">
-                            <select id="colour-{{ candidate|lower }}" class="form-select"
-                                    name="colour-{{ candidate|lower }}">
-                                <option
-                                    value="green"{% if colour == 'green' %} selected{% endif %}>{{ 'Green'|trans }}</option>
-                                <option
-                                    value="red"{% if colour == 'red' %} selected{% endif %}>{{ 'Red'|trans }}</option>
-                            </select>
+    <div data-controller="bo--prepare-elimination">
+        <div class="row">
+            <div class="col-12 col-md-6">
+                <form method="post">
+                    <input type="hidden" name="_token" value="{{ csrf_token('prepare_elimination') }}">
+                    {%~ for candidate, colour in elimination.data %}
+                        <div class="row mb-3">
+                            <label for="colour-{{ candidate|lower }}" class="col-4 col-form-label">{{ candidate }}</label>
+                            <div class="col-4">
+                                <select id="colour-{{ candidate|lower }}" class="form-select"
+                                        name="colour-{{ candidate|lower }}">
+                                    <option
+                                        value="green"{% if colour == 'green' %} selected{% endif %}>{{ 'Green'|trans }}</option>
+                                    <option
+                                        value="red"{% if colour == 'red' %} selected{% endif %}>{{ 'Red'|trans }}</option>
+                                </select>
+                            </div>
                         </div>
+                    {% endfor %}
+                    <div class="btn-group mb-3">
+                        <button type="submit" class="btn btn-primary" name="start" value="0">{{ 'Save'|trans }}</button>
+                        <button type="submit" class="btn btn-success" name="start"
+                                value="1">{{ 'Save and start elimination'|trans }}</button>
+                        <a href="{{ path('tvdt_backoffice_quiz', {seasonCode: elimination.quiz.season.seasonCode, quiz: elimination.quiz.id}) }}"
+                           class="btn btn-secondary">{{ 'Back'|trans }}</a>
+                        <button type="button" class="btn btn-danger"
+                                data-action="click->bo--prepare-elimination#deleteElimination">{{ 'Delete...'|trans }}</button>
                     </div>
-                {% endfor %}
-                <div class="btn-group mb-3">
-                    <button type="submit" class="btn btn-primary" name="start" value="0">{{ 'Save'|trans }}</button>
-                    <button type="submit" class="btn btn-success" name="start"
-                            value="1">{{ 'Save and start elimination'|trans }}</button>
-                    <a href="{{ path('tvdt_backoffice_quiz', {seasonCode: elimination.quiz.season.seasonCode, quiz: elimination.quiz.id}) }}"
-                       class="btn btn-secondary">{{ 'Back'|trans }}</a>
-                    <button type="button" class="btn btn-danger" data-bs-toggle="modal"
-                            data-bs-target="#deleteEliminationModal">{{ 'Delete...'|trans }}</button>
-                </div>
-            </form>
+                </form>
+            </div>
+            <div class="col-12 col-md-6">
+                {{ include('backoffice/help/prepare_elimination.html.twig') }}
+            </div>
         </div>
-        <div class="col-12 col-md-6">
-            {{ include('backoffice/help/prepare_elimination.html.twig') }}
-        </div>
-    </div>
 
-    <div class="modal fade" id="deleteEliminationModal" data-bs-backdrop="static"
-         tabindex="-1"
-         aria-labelledby="deleteEliminationModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h1 class="modal-title fs-5" id="deleteEliminationModalLabel">{{ 'Please Confirm'|trans }}</h1>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        {% if not elimination.screenViews.empty %}
+            <div class="row">
+                <div class="col-12 col-md-6">
+                    <h4 class="mb-3">{{ 'Screens shown'|trans }}</h4>
+                    <table class="table table-hover">
+                        <thead>
+                        <tr>
+                            <th scope="col">{{ 'Candidate'|trans }}</th>
+                            <th scope="col">{{ 'Colour'|trans }}</th>
+                            <th scope="col">{{ 'Shown at'|trans }}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {%~ for screenView in elimination.screenViews %}
+                            <tr>
+                                <td>{{ screenView.candidate.name }}</td>
+                                <td>{{ (screenView.colour == 'green' ? 'Green' : 'Red')|trans }}</td>
+                                <td>{{ screenView.created|format_datetime() }}</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
-                <div class="modal-body">{{ 'Are you sure you want to delete this elimination?'|trans }}</div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'No'|trans }}</button>
-                    <form action="{{ path('tvdt_prepare_elimination_delete', {elimination: elimination.id}) }}" method="POST">
-                        <input type="hidden" name="_token" value="{{ csrf_token('delete_elimination') }}">
-                        <button type="submit" class="btn btn-danger">{{ 'Yes'|trans }}</button>
-                    </form>
+            </div>
+        {% endif %}
+
+        <div class="modal fade" data-bo--prepare-elimination-target="deleteModal" data-bs-backdrop="static"
+             tabindex="-1"
+             aria-labelledby="deleteEliminationModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-5" id="deleteEliminationModalLabel">{{ 'Please Confirm'|trans }}</h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">{{ 'Are you sure you want to delete this elimination?'|trans }}</div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'No'|trans }}</button>
+                        <form action="{{ path('tvdt_prepare_elimination_delete', {elimination: elimination.id}) }}" method="POST">
+                            <input type="hidden" name="_token" value="{{ csrf_token('delete_elimination') }}">
+                            <button type="submit" class="btn btn-danger">{{ 'Yes'|trans }}</button>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/backoffice/prepare_elimination/index.html.twig
+++ b/templates/backoffice/prepare_elimination/index.html.twig
@@ -14,7 +14,7 @@
 {% block body %}
     <div data-controller="bo--prepare-elimination">
         <div class="row">
-            <div class="col-12 col-md-6">
+            <div class="col-12 col-md-6 order-1">
                 <form method="post">
                     <input type="hidden" name="_token" value="{{ csrf_token('prepare_elimination') }}">
                     <div class="row mb-2 fw-bold">
@@ -50,14 +50,9 @@
                     </div>
                 </form>
             </div>
-            <div class="col-12 col-md-6">
-                {{ include('backoffice/help/prepare_elimination.html.twig') }}
-            </div>
-        </div>
 
-        {% if not elimination.screenViews.empty %}
-            <div class="row">
-                <div class="col-12 col-md-6">
+            {% if not elimination.screenViews.empty %}
+                <div class="col-12 col-md-6 order-2 order-md-3 offset-md-6">
                     <h4 class="mb-3">{{ 'Screens shown'|trans }}</h4>
                     <table class="table table-hover">
                         <thead>
@@ -78,8 +73,12 @@
                         </tbody>
                     </table>
                 </div>
+            {% endif %}
+
+            <div class="col-12 col-md-6 order-3 order-md-2">
+                {{ include('backoffice/help/prepare_elimination.html.twig') }}
             </div>
-        {% endif %}
+        </div>
 
         <div class="modal fade" data-bo--prepare-elimination-target="deleteModal" data-bs-backdrop="static"
              tabindex="-1"

--- a/templates/backoffice/prepare_elimination/index.html.twig
+++ b/templates/backoffice/prepare_elimination/index.html.twig
@@ -17,16 +17,24 @@
             <div class="col-12 col-md-6">
                 <form method="post">
                     <input type="hidden" name="_token" value="{{ csrf_token('prepare_elimination') }}">
-                    {%~ for candidate, colour in elimination.data %}
-                        <div class="row mb-3">
-                            <label for="colour-{{ candidate|lower }}" class="col-4 col-form-label">{{ candidate }}</label>
+                    <div class="row mb-2 fw-bold">
+                        <div class="col-4">{{ 'Candidate'|trans }}</div>
+                        <div class="col-2">{{ 'Score'|trans }}</div>
+                        <div class="col-2">{{ 'Time'|trans }}</div>
+                        <div class="col-4">{{ 'Colour'|trans }}</div>
+                    </div>
+                    {%~ for name, result in candidates %}
+                        <div class="row mb-3 align-items-center">
+                            <label for="colour-{{ name|lower }}" class="col-4 col-form-label">{{ name }}</label>
+                            <div class="col-2">{{ result ? result.score : '-' }}</div>
+                            <div class="col-2">{{ result ? result.time.format('%i:%S') : '-' }}</div>
                             <div class="col-4">
-                                <select id="colour-{{ candidate|lower }}" class="form-select"
-                                        name="colour-{{ candidate|lower }}">
+                                <select id="colour-{{ name|lower }}" class="form-select colour-select"
+                                        name="colour-{{ name|lower }}">
                                     <option
-                                        value="green"{% if colour == 'green' %} selected{% endif %}>{{ 'Green'|trans }}</option>
+                                        value="green"{% if elimination.data[name] == 'green' %} selected{% endif %}>{{ 'Green'|trans }}</option>
                                     <option
-                                        value="red"{% if colour == 'red' %} selected{% endif %}>{{ 'Red'|trans }}</option>
+                                        value="red"{% if elimination.data[name] == 'red' %} selected{% endif %}>{{ 'Red'|trans }}</option>
                                 </select>
                             </div>
                         </div>

--- a/templates/backoffice/prepare_elimination/index.html.twig
+++ b/templates/backoffice/prepare_elimination/index.html.twig
@@ -36,11 +36,34 @@
                             value="1">{{ 'Save and start elimination'|trans }}</button>
                     <a href="{{ path('tvdt_backoffice_quiz', {seasonCode: elimination.quiz.season.seasonCode, quiz: elimination.quiz.id}) }}"
                        class="btn btn-secondary">{{ 'Back'|trans }}</a>
+                    <button type="button" class="btn btn-danger" data-bs-toggle="modal"
+                            data-bs-target="#deleteEliminationModal">{{ 'Delete...'|trans }}</button>
                 </div>
             </form>
         </div>
         <div class="col-12 col-md-6">
             {{ include('backoffice/help/prepare_elimination.html.twig') }}
+        </div>
+    </div>
+
+    <div class="modal fade" id="deleteEliminationModal" data-bs-backdrop="static"
+         tabindex="-1"
+         aria-labelledby="deleteEliminationModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="deleteEliminationModalLabel">{{ 'Please Confirm'|trans }}</h1>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">{{ 'Are you sure you want to delete this elimination?'|trans }}</div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'No'|trans }}</button>
+                    <form action="{{ path('tvdt_prepare_elimination_delete', {elimination: elimination.id}) }}" method="POST">
+                        <input type="hidden" name="_token" value="{{ csrf_token('delete_elimination') }}">
+                        <button type="submit" class="btn btn-danger">{{ 'Yes'|trans }}</button>
+                    </form>
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/templates/backoffice/prepare_elimination/index.html.twig
+++ b/templates/backoffice/prepare_elimination/index.html.twig
@@ -1,5 +1,7 @@
 {% extends 'backoffice/base.html.twig' %}
 
+{% block title %}{{ parent() }}{{ 'Prepare Elimination'|trans }}{% endblock %}
+
 {% block breadcrumbs %}
     <nav aria-label="breadcrumb" class="mb-3">
         <ol class="breadcrumb">
@@ -13,6 +15,7 @@
 
 {% block body %}
     <div data-controller="bo--prepare-elimination">
+        <h2 class="mb-3">{{ 'Prepare Elimination'|trans }}: {{ elimination.quiz.season.name }} - {{ elimination.quiz.name }}</h2>
         <div class="row">
             <div class="col-12 col-md-6 order-1">
                 <form method="post">
@@ -52,7 +55,7 @@
             </div>
 
             {% if not elimination.screenViews.empty %}
-                <div class="col-12 col-md-6 order-2 order-md-3 offset-md-6">
+                <div class="col-12 col-md-6 order-2">
                     <h4 class="mb-3">{{ 'Screens shown'|trans }}</h4>
                     <table class="table table-hover">
                         <thead>
@@ -75,7 +78,7 @@
                 </div>
             {% endif %}
 
-            <div class="col-12 col-md-6 order-3 order-md-2">
+            <div class="col-12 col-md-6 order-3">
                 {{ include('backoffice/help/prepare_elimination.html.twig') }}
             </div>
         </div>

--- a/templates/backoffice/prepare_elimination/index.html.twig
+++ b/templates/backoffice/prepare_elimination/index.html.twig
@@ -17,7 +17,7 @@
     <div data-controller="bo--prepare-elimination">
         <h2 class="mb-3">{{ 'Prepare Elimination'|trans }}: {{ elimination.quiz.season.name }} - {{ elimination.quiz.name }}</h2>
         <div class="row">
-            <div class="col-12 col-md-6 order-1">
+            <div class="col-12 col-md-6">
                 <form method="post">
                     <input type="hidden" name="_token" value="{{ csrf_token('prepare_elimination') }}">
                     <div class="row mb-2 fw-bold">
@@ -54,8 +54,12 @@
                 </form>
             </div>
 
-            {% if not elimination.screenViews.empty %}
-                <div class="col-12 col-md-6 order-2">
+            <div class="col-12 col-md-6">
+                <div class="mb-4">
+                    {{ include('backoffice/help/prepare_elimination.html.twig') }}
+                </div>
+
+                {% if not elimination.screenViews.empty %}
                     <h4 class="mb-3">{{ 'Screens shown'|trans }}</h4>
                     <table class="table table-hover">
                         <thead>
@@ -75,11 +79,7 @@
                         {% endfor %}
                         </tbody>
                     </table>
-                </div>
-            {% endif %}
-
-            <div class="col-12 col-md-6 order-3">
-                {{ include('backoffice/help/prepare_elimination.html.twig') }}
+                {% endif %}
             </div>
         </div>
 

--- a/templates/backoffice/quiz/tab_overview.html.twig
+++ b/templates/backoffice/quiz/tab_overview.html.twig
@@ -23,7 +23,7 @@
 {% endmacro %}
 
 <div class="row">
-<div class="col-md-8 col-12" data-controller="bo--quiz">
+<div class="col-xl-8 col-12" data-controller="bo--quiz">
     <h4 class="mb-3">
         {{ 'Quick actions'|trans }}
         {% if quiz.isFinalized %}
@@ -176,7 +176,7 @@
         csrf_token('delete_quiz'),
     ) }}
 </div>
-<div class="col-md-4 col-12">
+<div class="col-xl-4 col-12">
     {{ include('backoffice/help/quiz_overview.html.twig') }}
 </div>
 </div>

--- a/templates/backoffice/quiz/tab_result.html.twig
+++ b/templates/backoffice/quiz/tab_result.html.twig
@@ -20,7 +20,16 @@
         {% endif %}
     </div>
 </div>
-<p class="mb-3">{{ 'Number of dropouts:'|trans }}  {{ quiz.dropouts }} </p>
+<form method="post" class="d-flex align-items-center gap-2 mb-3"
+      action="{{ path('tvdt_backoffice_modify_dropouts', {quiz: quiz.id}) }}">
+    <input type="hidden" name="_token" value="{{ csrf_token('quiz_dropouts') }}">
+    <label for="dropouts" class="form-label mb-0">{{ 'Number of dropouts:'|trans }}</label>
+    <input class="form-control form-control-sm w-auto" type="number" min="1"
+           id="dropouts" name="dropouts" value="{{ quiz.dropouts }}">
+    <button class="btn btn-sm btn-primary" type="submit" title="{{ 'Save'|trans }}" aria-label="{{ 'Save'|trans }}">
+        <i class="bi bi-floppy"></i>
+    </button>
+</form>
 <table class="table table-hover table-result mb-3">
     <thead>
     <tr>
@@ -37,28 +46,19 @@
         <tr class="table-{% if loop.revindex > quiz.dropouts %}success{% else %}danger{% endif %}">
             <td>{{ candidate.name }}</td>
             <td>{{ candidate.correct|default('0') }}</td>
-            <td>
-                <form method="post"
-                      action="{{ path('tvdt_backoffice_modify_correction', {quiz: quiz.id, candidate: candidate.id}) }}">
-                    <input type="hidden" name="_token" value="{{ csrf_token('candidate_correction') }}">
-                    <div class="d-flex gap-1">
-                        <input class="form-control form-control-sm" type="number"
-                               value="{{ candidate.corrections }}" step="0.5"
-                               name="corrections">
-                        <button class="btn btn-sm btn-primary" type="submit">{{ 'Save'|trans }}</button>
-                    </div>
-                </form>
-            </td>
-            <td>
-                <form method="post"
-                      action="{{ path('tvdt_backoffice_modify_penalty', {quiz: quiz.id, candidate: candidate.id}) }}">
-                    <input type="hidden" name="_token" value="{{ csrf_token('candidate_penalty') }}">
-                    <div class="d-flex gap-1">
-                        <input class="form-control form-control-sm" type="number"
-                               value="{{ candidate.penaltySeconds }}" step="1"
-                               name="penalty">
-                        <button class="btn btn-sm btn-primary" type="submit">{{ 'Save'|trans }}</button>
-                    </div>
+            <td colspan="2">
+                <form method="post" class="d-flex gap-1"
+                      action="{{ path('tvdt_backoffice_modify_result', {quiz: quiz.id, candidate: candidate.id}) }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('candidate_result') }}">
+                    <input class="form-control form-control-sm" type="number"
+                           value="{{ candidate.corrections }}" step="0.5"
+                           name="corrections" aria-label="{{ 'Corrections'|trans }}">
+                    <input class="form-control form-control-sm" type="number"
+                           value="{{ candidate.penaltySeconds }}" step="1"
+                           name="penalty" aria-label="{{ 'Penalty'|trans }}">
+                    <button class="btn btn-sm btn-primary" type="submit" title="{{ 'Save'|trans }}" aria-label="{{ 'Save'|trans }}">
+                        <i class="bi bi-floppy"></i>
+                    </button>
                 </form>
             </td>
             <td>{{ candidate.score|default('x') }}</td>

--- a/templates/quiz/elimination/candidate.html.twig
+++ b/templates/quiz/elimination/candidate.html.twig
@@ -1,5 +1,6 @@
 {% extends 'quiz/base.html.twig' %}
 
+{% block nav %}{% endblock %}
 {% block body %}
     <img src="{{ asset("img/#{colour}.png") }}"
          class="elimination-screen" id="{{ colour }}"

--- a/templates/quiz/elimination/index.html.twig
+++ b/templates/quiz/elimination/index.html.twig
@@ -1,4 +1,7 @@
 {% extends 'quiz/base.html.twig' %}
+{% block nav %}{% endblock %}
 {% block body %}
-    {{ form(form) }}
+    <div class="quiz-form-narrow">
+        {{ form(form) }}
+    </div>
 {% endblock body %}

--- a/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
+++ b/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
@@ -109,6 +109,49 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         self::assertSelectorNotExists('table');
     }
 
+    public function testViewEliminationShowsCandidatesOrderedByScoreWithTime(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $tom = $this->getCandidate('Tom');
+        $claudia = $this->getCandidate('Claudia');
+
+        $questions = $quiz->questions;
+        $firstQuestion = $questions->first();
+        $secondQuestion = $questions->get(1);
+        $this->assertInstanceOf(Question::class, $firstQuestion);
+        $this->assertInstanceOf(Question::class, $secondQuestion);
+        $firstAnswer = $firstQuestion->answers->first();
+        $secondAnswer = $secondQuestion->answers->first();
+        $this->assertInstanceOf(Answer::class, $firstAnswer);
+        $this->assertInstanceOf(Answer::class, $secondAnswer);
+
+        // Tom answers both questions correctly, Claudia only the first: Tom should score higher and rank first.
+        $tomQuizCandidate = new QuizCandidate($quiz, $tom);
+        $tomQuizCandidate->started = new DateTimeImmutable();
+
+        $this->entityManager->persist($tomQuizCandidate);
+        $this->entityManager->persist(new GivenAnswer($tom, $quiz, $firstAnswer));
+        $this->entityManager->persist(new GivenAnswer($tom, $quiz, $secondAnswer));
+
+        $claudiaQuizCandidate = new QuizCandidate($quiz, $claudia);
+        $claudiaQuizCandidate->started = new DateTimeImmutable();
+
+        $this->entityManager->persist($claudiaQuizCandidate);
+        $this->entityManager->persist(new GivenAnswer($claudia, $quiz, $firstAnswer));
+
+        $elimination = new Elimination($quiz);
+        $elimination->data = ['Claudia' => Elimination::SCREEN_GREEN, 'Tom' => Elimination::SCREEN_GREEN];
+
+        $this->entityManager->persist($elimination);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/elimination/%s', $elimination->id));
+
+        self::assertResponseIsSuccessful();
+        $labels = $crawler->filter('label')->each(static fn ($node): string => mb_trim((string) $node->text()));
+        $this->assertSame(['Tom', 'Claudia'], $labels);
+    }
+
     public function testViewEliminationSavesUpdatedColours(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');

--- a/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
+++ b/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
@@ -80,7 +80,9 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         $quiz = $this->getQuizByName('Quiz 1');
         $candidate = $this->getCandidate('Tom');
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        // Elimination's current colour is red, but the logged screen view was green: the log must show the
+        // historical view colour, not whatever the elimination happens to say now.
+        $elimination->data = ['Tom' => Elimination::SCREEN_RED];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->persist(new EliminationScreenView($elimination, $candidate, Elimination::SCREEN_GREEN));
@@ -120,8 +122,8 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         $secondQuestion = $questions->get(1);
         $this->assertInstanceOf(Question::class, $firstQuestion);
         $this->assertInstanceOf(Question::class, $secondQuestion);
-        $firstAnswer = $firstQuestion->answers->first();
-        $secondAnswer = $secondQuestion->answers->first();
+        $firstAnswer = $firstQuestion->answers->filter(static fn (Answer $answer): bool => $answer->isRightAnswer)->first();
+        $secondAnswer = $secondQuestion->answers->filter(static fn (Answer $answer): bool => $answer->isRightAnswer)->first();
         $this->assertInstanceOf(Answer::class, $firstAnswer);
         $this->assertInstanceOf(Answer::class, $secondAnswer);
 
@@ -199,13 +201,17 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
     public function testDeleteEliminationRemovesEliminationAndRedirectsToQuiz(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');
+        $candidate = $this->getCandidate('Tom');
         $elimination = new Elimination($quiz);
         $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
 
         $this->entityManager->persist($elimination);
+        $screenView = new EliminationScreenView($elimination, $candidate, Elimination::SCREEN_GREEN);
+        $this->entityManager->persist($screenView);
         $this->entityManager->flush();
 
         $eliminationId = $elimination->id;
+        $screenViewId = $screenView->id;
 
         $token = $this->getCsrfTokenFromPage(\sprintf('/backoffice/elimination/%s', $elimination->id), \sprintf('/backoffice/elimination/%s/delete', $elimination->id));
 
@@ -217,6 +223,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         $this->entityManager->clear();
 
         $this->assertNotInstanceOf(Elimination::class, $this->entityManager->getRepository(Elimination::class)->find($eliminationId));
+        $this->assertNotInstanceOf(EliminationScreenView::class, $this->entityManager->getRepository(EliminationScreenView::class)->find($screenViewId));
     }
 
     public function testDeleteEliminationIsDeniedForNonOwner(): void

--- a/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
+++ b/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Tvdt\Controller\Backoffice\PrepareEliminationController;
 use Tvdt\Entity\Answer;
 use Tvdt\Entity\Elimination;
+use Tvdt\Entity\EliminationScreenView;
 use Tvdt\Entity\GivenAnswer;
 use Tvdt\Entity\Question;
 use Tvdt\Entity\QuizCandidate;
@@ -72,6 +73,40 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
 
         self::assertResponseIsSuccessful();
         self::assertSelectorExists('form');
+    }
+
+    public function testViewEliminationPageShowsScreenViewLog(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $candidate = $this->getCandidate('Tom');
+        $elimination = new Elimination($quiz);
+        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+
+        $this->entityManager->persist($elimination);
+        $this->entityManager->persist(new EliminationScreenView($elimination, $candidate, Elimination::SCREEN_GREEN));
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/elimination/%s', $elimination->id));
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('table', 'Tom');
+        self::assertSelectorTextContains('table', 'Groen');
+    }
+
+    public function testViewEliminationPageHidesScreenViewLogWhenEmpty(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $elimination = new Elimination($quiz);
+        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+
+        $this->entityManager->persist($elimination);
+        $this->entityManager->flush();
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/elimination/%s', $elimination->id));
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('table');
     }
 
     public function testViewEliminationSavesUpdatedColours(): void

--- a/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
+++ b/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
@@ -118,6 +118,49 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         self::assertResponseRedirects(\sprintf('/elimination/%s', $elimination->id));
     }
 
+    public function testDeleteEliminationRemovesEliminationAndRedirectsToQuiz(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $elimination = new Elimination($quiz);
+        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+
+        $this->entityManager->persist($elimination);
+        $this->entityManager->flush();
+
+        $eliminationId = $elimination->id;
+
+        $token = $this->getCsrfTokenFromPage(\sprintf('/backoffice/elimination/%s', $elimination->id), \sprintf('/backoffice/elimination/%s/delete', $elimination->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/elimination/%s/delete', $elimination->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/backoffice/season/krtek/quiz/%s', $quiz->id));
+        $this->entityManager->clear();
+
+        $this->assertNotInstanceOf(Elimination::class, $this->entityManager->getRepository(Elimination::class)->find($eliminationId));
+    }
+
+    public function testDeleteEliminationIsDeniedForNonOwner(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $elimination = new Elimination($quiz);
+        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+
+        $this->entityManager->persist($elimination);
+        $this->entityManager->flush();
+
+        $token = $this->getCsrfTokenFromPage(\sprintf('/backoffice/elimination/%s', $elimination->id), \sprintf('/backoffice/elimination/%s/delete', $elimination->id));
+
+        $this->loginAs('test@example.org');
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/elimination/%s/delete', $elimination->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
     public function testIndexIsDeniedForNonOwner(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');

--- a/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
+++ b/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
@@ -116,6 +116,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         $quiz = $this->getQuizByName('Quiz 1');
         $tom = $this->getCandidate('Tom');
         $claudia = $this->getCandidate('Claudia');
+        $iris = $this->getCandidate('Iris');
 
         $questions = $quiz->questions;
         $firstQuestion = $questions->first();
@@ -127,22 +128,37 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         $this->assertInstanceOf(Answer::class, $firstAnswer);
         $this->assertInstanceOf(Answer::class, $secondAnswer);
 
-        // Tom answers both questions correctly, Claudia only the first: Tom should score higher and rank first.
+        // Tom answers both questions correctly: highest score, ranks first.
+        // Claudia and Iris both answer only the first question correctly (tied score), but Claudia's answer is
+        // persisted a full second before Iris's: the tie must be broken by elapsed time, not insertion order.
+        // A real sleep (rather than a mocked clock) is used because `given_answer.created` is TIMESTAMP(0) —
+        // second precision — and the container's clock is already initialised by client/login by this point.
+        $started = new DateTimeImmutable();
         $tomQuizCandidate = new QuizCandidate($quiz, $tom);
-        $tomQuizCandidate->started = new DateTimeImmutable();
+        $tomQuizCandidate->started = $started;
 
         $this->entityManager->persist($tomQuizCandidate);
-        $this->entityManager->persist(new GivenAnswer($tom, $quiz, $firstAnswer));
-        $this->entityManager->persist(new GivenAnswer($tom, $quiz, $secondAnswer));
 
         $claudiaQuizCandidate = new QuizCandidate($quiz, $claudia);
-        $claudiaQuizCandidate->started = new DateTimeImmutable();
+        $claudiaQuizCandidate->started = $started;
 
         $this->entityManager->persist($claudiaQuizCandidate);
+
+        $irisQuizCandidate = new QuizCandidate($quiz, $iris);
+        $irisQuizCandidate->started = $started;
+
+        $this->entityManager->persist($irisQuizCandidate);
+
+        $this->entityManager->persist(new GivenAnswer($tom, $quiz, $firstAnswer));
+        $this->entityManager->persist(new GivenAnswer($tom, $quiz, $secondAnswer));
         $this->entityManager->persist(new GivenAnswer($claudia, $quiz, $firstAnswer));
+        $this->entityManager->flush();
+
+        sleep(1);
+        $this->entityManager->persist(new GivenAnswer($iris, $quiz, $firstAnswer));
 
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Claudia' => Elimination::SCREEN_GREEN, 'Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Claudia' => Elimination::SCREEN_GREEN, 'Tom' => Elimination::SCREEN_GREEN, 'Iris' => Elimination::SCREEN_GREEN];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->flush();
@@ -151,7 +167,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
 
         self::assertResponseIsSuccessful();
         $labels = $crawler->filter('label')->each(static fn ($node): string => mb_trim((string) $node->text()));
-        $this->assertSame(['Tom', 'Claudia'], $labels);
+        $this->assertSame(['Tom', 'Claudia', 'Iris'], $labels);
     }
 
     public function testViewEliminationSavesUpdatedColours(): void

--- a/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
+++ b/tests/Controller/Backoffice/PrepareEliminationControllerTest.php
@@ -14,6 +14,7 @@ use Tvdt\Entity\EliminationScreenView;
 use Tvdt\Entity\GivenAnswer;
 use Tvdt\Entity\Question;
 use Tvdt\Entity\QuizCandidate;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Tests\Controller\AbstractControllerWebTestCase;
 
 #[CoversClass(PrepareEliminationController::class)]
@@ -64,7 +65,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
     {
         $quiz = $this->getQuizByName('Quiz 1');
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Tom' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->flush();
@@ -82,10 +83,10 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         $elimination = new Elimination($quiz);
         // Elimination's current colour is red, but the logged screen view was green: the log must show the
         // historical view colour, not whatever the elimination happens to say now.
-        $elimination->data = ['Tom' => Elimination::SCREEN_RED];
+        $elimination->data = ['Tom' => ScreenColour::Red->value];
 
         $this->entityManager->persist($elimination);
-        $this->entityManager->persist(new EliminationScreenView($elimination, $candidate, Elimination::SCREEN_GREEN));
+        $this->entityManager->persist(new EliminationScreenView($elimination, $candidate, ScreenColour::Green));
         $this->entityManager->flush();
         $this->entityManager->clear();
 
@@ -100,7 +101,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
     {
         $quiz = $this->getQuizByName('Quiz 1');
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Tom' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->flush();
@@ -158,7 +159,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         $this->entityManager->persist(new GivenAnswer($iris, $quiz, $firstAnswer));
 
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Claudia' => Elimination::SCREEN_GREEN, 'Tom' => Elimination::SCREEN_GREEN, 'Iris' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Claudia' => ScreenColour::Green->value, 'Tom' => ScreenColour::Green->value, 'Iris' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->flush();
@@ -174,7 +175,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
     {
         $quiz = $this->getQuizByName('Quiz 1');
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Tom' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->flush();
@@ -183,7 +184,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
 
         $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/elimination/%s', $elimination->id), [
             '_token' => $token,
-            'colour-tom' => Elimination::SCREEN_RED,
+            'colour-tom' => ScreenColour::Red->value,
             'start' => '0',
         ]);
 
@@ -192,14 +193,14 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
 
         $updated = $this->entityManager->getRepository(Elimination::class)->find($elimination->id);
         $this->assertInstanceOf(Elimination::class, $updated);
-        $this->assertSame(Elimination::SCREEN_RED, $updated->data['Tom']);
+        $this->assertSame(ScreenColour::Red->value, $updated->data['Tom']);
     }
 
     public function testViewEliminationWithStartRedirectsToPublicElimination(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Tom' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->flush();
@@ -219,10 +220,10 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
         $quiz = $this->getQuizByName('Quiz 1');
         $candidate = $this->getCandidate('Tom');
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Tom' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
-        $screenView = new EliminationScreenView($elimination, $candidate, Elimination::SCREEN_GREEN);
+        $screenView = new EliminationScreenView($elimination, $candidate, ScreenColour::Green);
         $this->entityManager->persist($screenView);
         $this->entityManager->flush();
 
@@ -246,7 +247,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
     {
         $quiz = $this->getQuizByName('Quiz 1');
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Tom' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->flush();
@@ -280,7 +281,7 @@ final class PrepareEliminationControllerTest extends AbstractControllerWebTestCa
     {
         $quiz = $this->getQuizByName('Quiz 1');
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Tom' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
         $this->entityManager->flush();

--- a/tests/Controller/Backoffice/QuestionBankControllerTest.php
+++ b/tests/Controller/Backoffice/QuestionBankControllerTest.php
@@ -224,7 +224,7 @@ final class QuestionBankControllerTest extends AbstractControllerWebTestCase
     public function testAssignSameReusableQuestionTwiceToSameQuizIsRefused(): void
     {
         $this->loginAs('krtek-admin@example.org');
-        $bankQuestion = $this->getBankQuestion('Wie is de Krtek?');
+        $bankQuestion = $this->getBankQuestion('Wat is de bijnaam van de Krtek?');
         $quiz = $this->getQuizByName('Quiz 2');
         $questionCount = $quiz->questions->count();
 

--- a/tests/Controller/Backoffice/QuizControllerTest.php
+++ b/tests/Controller/Backoffice/QuizControllerTest.php
@@ -214,7 +214,7 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
         $this->assertCount(0, $remainingAnswers);
     }
 
-    public function testModifyCorrection(): void
+    public function testModifyResult(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');
         $candidate = $this->getCandidate('Tom');
@@ -233,11 +233,12 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
 
         $crawler = $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s/result', $quiz->id));
         self::assertResponseIsSuccessful();
-        $token = (string) $crawler->filter(\sprintf('form[action*="%s/modify_correction"] input[name="_token"]', $candidate->id))->first()->attr('value');
+        $token = (string) $crawler->filter(\sprintf('form[action*="%s/modify_result"] input[name="_token"]', $candidate->id))->first()->attr('value');
 
-        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/candidate/%s/modify_correction', $quiz->id, $candidate->id), [
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/candidate/%s/modify_result', $quiz->id, $candidate->id), [
             '_token' => $token,
             'corrections' => '1.5',
+            'penalty' => '30',
         ]);
 
         self::assertResponseRedirects();
@@ -249,42 +250,25 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
         ]);
         $this->assertInstanceOf(QuizCandidate::class, $updated);
         $this->assertEqualsWithDelta(1.5, $updated->corrections, \PHP_FLOAT_EPSILON);
+        $this->assertSame(30, $updated->penaltySeconds);
     }
 
-    public function testModifyPenalty(): void
+    public function testModifyDropouts(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');
-        $candidate = $this->getCandidate('Claudia');
 
-        $quizCandidate = new QuizCandidate($quiz, $candidate);
-        $quizCandidate->started = new DateTimeImmutable();
+        $token = $this->getCsrfTokenFromPage(\sprintf('/backoffice/season/krtek/quiz/%s/result', $quiz->id), '/modify_dropouts');
 
-        $this->entityManager->persist($quizCandidate);
-        $firstQuestion = $quiz->questions->first();
-        $this->assertInstanceOf(Question::class, $firstQuestion);
-        $answer = $firstQuestion->answers->first();
-        $this->assertInstanceOf(Answer::class, $answer);
-        $this->entityManager->persist(new GivenAnswer($candidate, $quiz, $answer));
-        $this->entityManager->flush();
-
-        $crawler = $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s/result', $quiz->id));
-        self::assertResponseIsSuccessful();
-        $token = (string) $crawler->filter(\sprintf('form[action*="%s/modify_penalty"] input[name="_token"]', $candidate->id))->first()->attr('value');
-
-        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/candidate/%s/modify_penalty', $quiz->id, $candidate->id), [
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/modify_dropouts', $quiz->id), [
             '_token' => $token,
-            'penalty' => '30',
+            'dropouts' => '2',
         ]);
 
         self::assertResponseRedirects();
         $this->entityManager->clear();
 
-        $updated = $this->entityManager->getRepository(QuizCandidate::class)->findOneBy([
-            'quiz' => $this->getQuizByName('Quiz 1'),
-            'candidate' => $this->getCandidate('Claudia'),
-        ]);
-        $this->assertInstanceOf(QuizCandidate::class, $updated);
-        $this->assertSame(30, $updated->penaltySeconds);
+        $updated = $this->getQuizByName('Quiz 1');
+        $this->assertSame(2, $updated->dropouts);
     }
 
     public function testDeleteQuiz(): void

--- a/tests/Controller/Backoffice/QuizControllerTest.php
+++ b/tests/Controller/Backoffice/QuizControllerTest.php
@@ -89,6 +89,20 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
         self::assertResponseIsSuccessful();
     }
 
+    public function testCandidatesQuestionRejectsQuestionFromAnotherQuiz(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+
+        $otherQuiz = $this->entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Doomed Quiz']);
+        $this->assertInstanceOf(Quiz::class, $otherQuiz);
+        $otherQuestion = $otherQuiz->questions->first();
+        $this->assertInstanceOf(Question::class, $otherQuestion);
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s/candidates/%s', $quiz->id, $otherQuestion->id));
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
     public function testSaveCandidateAnswersPersistsSelection(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');
@@ -269,6 +283,24 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
 
         $updated = $this->getQuizByName('Quiz 1');
         $this->assertSame(2, $updated->dropouts);
+    }
+
+    public function testModifyDropoutsClampsToOne(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+
+        $token = $this->getCsrfTokenFromPage(\sprintf('/backoffice/season/krtek/quiz/%s/result', $quiz->id), '/modify_dropouts');
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/modify_dropouts', $quiz->id), [
+            '_token' => $token,
+            'dropouts' => '0',
+        ]);
+
+        self::assertResponseRedirects();
+        $this->entityManager->clear();
+
+        $updated = $this->getQuizByName('Quiz 1');
+        $this->assertSame(1, $updated->dropouts);
     }
 
     public function testDeleteQuiz(): void

--- a/tests/Controller/Backoffice/SeasonControllerTest.php
+++ b/tests/Controller/Backoffice/SeasonControllerTest.php
@@ -12,6 +12,7 @@ use Tvdt\Entity\Elimination;
 use Tvdt\Entity\EliminationScreenView;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Tests\Controller\AbstractControllerWebTestCase;
 
 #[CoversClass(SeasonController::class)]
@@ -115,9 +116,9 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
         $this->assertInstanceOf(Quiz::class, $quiz);
 
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Tom' => ScreenColour::Green->value];
 
-        $screenView = new EliminationScreenView($elimination, $candidate, Elimination::SCREEN_GREEN);
+        $screenView = new EliminationScreenView($elimination, $candidate, ScreenColour::Green);
 
         $this->entityManager->persist($elimination);
         $this->entityManager->persist($screenView);

--- a/tests/Controller/Backoffice/SeasonControllerTest.php
+++ b/tests/Controller/Backoffice/SeasonControllerTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\HttpFoundation\Request;
 use Tvdt\Controller\Backoffice\SeasonController;
 use Tvdt\Entity\Candidate;
+use Tvdt\Entity\Elimination;
+use Tvdt\Entity\EliminationScreenView;
+use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Tests\Controller\AbstractControllerWebTestCase;
 
@@ -102,6 +105,37 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
         $this->entityManager->clear();
 
         $this->assertNotInstanceOf(Candidate::class, $this->entityManager->getRepository(Candidate::class)->find($candidateId));
+    }
+
+    public function testDeleteCandidateCascadesEliminationScreenViews(): void
+    {
+        $candidate = $this->getCandidate('Tom');
+        $candidateId = $candidate->id;
+        $quiz = $this->entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Quiz 1']);
+        $this->assertInstanceOf(Quiz::class, $quiz);
+
+        $elimination = new Elimination($quiz);
+        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+
+        $screenView = new EliminationScreenView($elimination, $candidate, Elimination::SCREEN_GREEN);
+
+        $this->entityManager->persist($elimination);
+        $this->entityManager->persist($screenView);
+        $this->entityManager->flush();
+
+        $screenViewId = $screenView->id;
+
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/candidates', \sprintf('/candidate/%s/delete', $candidate->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/candidate/%s/delete', $candidate->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/candidates');
+        $this->entityManager->clear();
+
+        $this->assertNotInstanceOf(Candidate::class, $this->entityManager->getRepository(Candidate::class)->find($candidateId));
+        $this->assertNotInstanceOf(EliminationScreenView::class, $this->entityManager->getRepository(EliminationScreenView::class)->find($screenViewId));
     }
 
     public function testAddCandidates(): void

--- a/tests/Controller/EliminationControllerTest.php
+++ b/tests/Controller/EliminationControllerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\HttpFoundation\Request;
 use Tvdt\Controller\EliminationController;
 use Tvdt\Entity\Elimination;
+use Tvdt\Entity\EliminationScreenView;
 use Tvdt\Helpers\Base64;
 
 #[CoversClass(EliminationController::class)]
@@ -82,5 +83,36 @@ final class EliminationControllerTest extends AbstractControllerWebTestCase
 
         self::assertResponseIsSuccessful();
         self::assertSelectorExists(\sprintf('#%s', Elimination::SCREEN_GREEN));
+    }
+
+    public function testCandidateScreenRecordsScreenView(): void
+    {
+        $this->client->request(Request::METHOD_GET, \sprintf('/elimination/%s/%s', $this->elimination->id, Base64::base64UrlEncode('Tom')));
+
+        self::assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $eliminationId = $this->elimination->id;
+        $screenViews = $this->entityManager->getRepository(EliminationScreenView::class)->findBy(['elimination' => $eliminationId]);
+
+        $this->assertCount(1, $screenViews);
+        $this->assertSame('Tom', $screenViews[0]->candidate->name);
+        $this->assertSame(Elimination::SCREEN_GREEN, $screenViews[0]->colour);
+    }
+
+    public function testCandidateScreenRecordsScreenViewsInOrder(): void
+    {
+        $this->elimination->data = ['Tom' => Elimination::SCREEN_GREEN, 'Claudia' => Elimination::SCREEN_RED];
+        $this->entityManager->flush();
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/elimination/%s/%s', $this->elimination->id, Base64::base64UrlEncode('Claudia')));
+        $this->client->request(Request::METHOD_GET, \sprintf('/elimination/%s/%s', $this->elimination->id, Base64::base64UrlEncode('Tom')));
+
+        $this->entityManager->clear();
+        $elimination = $this->entityManager->getRepository(Elimination::class)->find($this->elimination->id);
+        $this->assertInstanceOf(Elimination::class, $elimination);
+        $names = array_map(static fn (EliminationScreenView $screenView): string => $screenView->candidate->name, $elimination->screenViews->toArray());
+
+        $this->assertSame(['Claudia', 'Tom'], $names);
     }
 }

--- a/tests/Controller/EliminationControllerTest.php
+++ b/tests/Controller/EliminationControllerTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Tvdt\Controller\EliminationController;
 use Tvdt\Entity\Elimination;
 use Tvdt\Entity\EliminationScreenView;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Helpers\Base64;
 
 #[CoversClass(EliminationController::class)]
@@ -23,7 +24,7 @@ final class EliminationControllerTest extends AbstractControllerWebTestCase
         $quiz = $this->getQuizByName('Quiz 1');
 
         $this->elimination = new Elimination($quiz);
-        $this->elimination->data = ['Tom' => Elimination::SCREEN_GREEN];
+        $this->elimination->data = ['Tom' => ScreenColour::Green->value];
 
         $this->entityManager->persist($this->elimination);
         $this->entityManager->flush();
@@ -82,7 +83,7 @@ final class EliminationControllerTest extends AbstractControllerWebTestCase
         $this->client->request(Request::METHOD_GET, \sprintf('/elimination/%s/%s', $this->elimination->id, Base64::base64UrlEncode('Tom')));
 
         self::assertResponseIsSuccessful();
-        self::assertSelectorExists(\sprintf('#%s', Elimination::SCREEN_GREEN));
+        self::assertSelectorExists(\sprintf('#%s', ScreenColour::Green->value));
     }
 
     public function testCandidateScreenRecordsScreenView(): void
@@ -97,12 +98,12 @@ final class EliminationControllerTest extends AbstractControllerWebTestCase
 
         $this->assertCount(1, $screenViews);
         $this->assertSame('Tom', $screenViews[0]->candidate->name);
-        $this->assertSame(Elimination::SCREEN_GREEN, $screenViews[0]->colour);
+        $this->assertSame(ScreenColour::Green, $screenViews[0]->colour);
     }
 
     public function testCandidateScreenRecordsScreenViewsInOrder(): void
     {
-        $this->elimination->data = ['Tom' => Elimination::SCREEN_GREEN, 'Claudia' => Elimination::SCREEN_RED];
+        $this->elimination->data = ['Tom' => ScreenColour::Green->value, 'Claudia' => ScreenColour::Red->value];
         $this->entityManager->flush();
 
         $this->client->request(Request::METHOD_GET, \sprintf('/elimination/%s/%s', $this->elimination->id, Base64::base64UrlEncode('Claudia')));

--- a/tests/Entity/EliminationTest.php
+++ b/tests/Entity/EliminationTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\InputBag;
 use Tvdt\Entity\Elimination;
 use Tvdt\Entity\Quiz;
+use Tvdt\Enum\ScreenColour;
 
 #[CoversClass(Elimination::class)]
 final class EliminationTest extends TestCase
@@ -17,44 +18,62 @@ final class EliminationTest extends TestCase
     {
         $elimination = new Elimination(new Quiz());
 
-        $this->assertNull($elimination->getScreenColour(null));
+        $this->assertNotInstanceOf(ScreenColour::class, $elimination->getScreenColour(null));
     }
 
     public function testGetScreenColourReturnsNullForUnknownName(): void
     {
         $elimination = new Elimination(new Quiz());
-        $elimination->data = $this->colours(['Tom' => Elimination::SCREEN_GREEN]);
+        $elimination->data = $this->colours(['Tom' => ScreenColour::Green]);
 
-        $this->assertNull($elimination->getScreenColour('Claudia'));
+        $this->assertNotInstanceOf(ScreenColour::class, $elimination->getScreenColour('Claudia'));
     }
 
     public function testGetScreenColourReturnsColourForKnownName(): void
     {
         $elimination = new Elimination(new Quiz());
-        $elimination->data = $this->colours(['Tom' => Elimination::SCREEN_GREEN, 'Claudia' => Elimination::SCREEN_RED]);
+        $elimination->data = $this->colours(['Tom' => ScreenColour::Green, 'Claudia' => ScreenColour::Red]);
 
-        $this->assertSame(Elimination::SCREEN_RED, $elimination->getScreenColour('Claudia'));
+        $this->assertSame(ScreenColour::Red, $elimination->getScreenColour('Claudia'));
+    }
+
+    public function testGetScreenColourReturnsNullForInvalidStoredValue(): void
+    {
+        $elimination = new Elimination(new Quiz());
+        $elimination->data = ['Tom' => 'not-a-colour'];
+
+        $this->assertNotInstanceOf(ScreenColour::class, $elimination->getScreenColour('Tom'));
     }
 
     public function testUpdateFromInputBagUpdatesKnownColours(): void
     {
         $elimination = new Elimination(new Quiz());
-        $elimination->data = $this->colours(['Tom' => Elimination::SCREEN_GREEN, 'Claudia' => Elimination::SCREEN_RED]);
+        $elimination->data = $this->colours(['Tom' => ScreenColour::Green, 'Claudia' => ScreenColour::Red]);
 
-        $elimination->updateFromInputBag($this->inputBag(['colour-tom' => Elimination::SCREEN_RED]));
+        $elimination->updateFromInputBag($this->inputBag(['colour-tom' => ScreenColour::Red->value]));
 
-        $this->assertSame(Elimination::SCREEN_RED, $elimination->data['Tom']);
-        $this->assertSame(Elimination::SCREEN_RED, $elimination->data['Claudia']);
+        $this->assertSame(ScreenColour::Red->value, $elimination->data['Tom']);
+        $this->assertSame(ScreenColour::Red->value, $elimination->data['Claudia']);
     }
 
     public function testUpdateFromInputBagIgnoresMissingInput(): void
     {
         $elimination = new Elimination(new Quiz());
-        $elimination->data = $this->colours(['Tom' => Elimination::SCREEN_GREEN]);
+        $elimination->data = $this->colours(['Tom' => ScreenColour::Green]);
 
         $elimination->updateFromInputBag($this->inputBag([]));
 
-        $this->assertSame(Elimination::SCREEN_GREEN, $elimination->data['Tom']);
+        $this->assertSame(ScreenColour::Green->value, $elimination->data['Tom']);
+    }
+
+    public function testUpdateFromInputBagIgnoresInvalidColour(): void
+    {
+        $elimination = new Elimination(new Quiz());
+        $elimination->data = $this->colours(['Tom' => ScreenColour::Green]);
+
+        $elimination->updateFromInputBag($this->inputBag(['colour-tom' => 'purple']));
+
+        $this->assertSame(ScreenColour::Green->value, $elimination->data['Tom']);
     }
 
     public function testUpdateFromInputBagReturnsSelf(): void
@@ -65,13 +84,13 @@ final class EliminationTest extends TestCase
     }
 
     /**
-     * @param array<string, string> $colours
+     * @param array<string, ScreenColour> $colours
      *
      * @return array<string, string>
      */
     private function colours(array $colours): array
     {
-        return $colours;
+        return array_map(static fn (ScreenColour $colour): string => $colour->value, $colours);
     }
 
     /**

--- a/tests/Repository/BankQuestionRepositoryTest.php
+++ b/tests/Repository/BankQuestionRepositoryTest.php
@@ -26,7 +26,7 @@ final class BankQuestionRepositoryTest extends DatabaseTestCase
 
         $bankQuestions = $this->bankQuestionRepository->findBySeason($season);
 
-        $this->assertCount(3, $bankQuestions);
+        $this->assertCount(70, $bankQuestions);
     }
 
     public function testFindBySeasonFiltersByLabel(): void

--- a/tests/Repository/QuestionRepositoryTest.php
+++ b/tests/Repository/QuestionRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tvdt\Tests\Repository;
 
+use Doctrine\ORM\PersistentCollection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Tvdt\Entity\Answer;
 use Tvdt\Entity\Candidate;
@@ -71,6 +72,34 @@ final class QuestionRepositoryTest extends DatabaseTestCase
         $question = $this->questionRepository->findNextQuestionForCandidate($candidate);
 
         $this->assertNotInstanceOf(Question::class, $question);
+    }
+
+    public function testFetchWithAnswerCandidatesEagerLoadsCandidates(): void
+    {
+        $krtekSeason = $this->getSeasonByCode('krtek');
+        $quiz = $krtekSeason->quizzes->first();
+        $this->assertInstanceOf(Quiz::class, $quiz);
+        $question = $quiz->questions->first();
+        $this->assertInstanceOf(Question::class, $question);
+        $answer = $question->answers->first();
+        $this->assertInstanceOf(Answer::class, $answer);
+        $candidate = $this->getCandidateBySeasonAndName($krtekSeason, 'Iris');
+        $candidateId = $candidate->id->toString();
+        $answer->addCandidate($candidate);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $fetched = $this->questionRepository->fetchWithAnswerCandidates($question->id);
+
+        $this->assertInstanceOf(PersistentCollection::class, $fetched->answers);
+        $this->assertTrue($fetched->answers->isInitialized());
+        $fetchedAnswer = $fetched->answers->first();
+        $this->assertInstanceOf(Answer::class, $fetchedAnswer);
+        $this->assertInstanceOf(PersistentCollection::class, $fetchedAnswer->candidates);
+        $this->assertTrue($fetchedAnswer->candidates->isInitialized());
+        $this->assertTrue($fetchedAnswer->candidates->exists(
+            static fn (int $key, Candidate $c): bool => $c->id->toString() === $candidateId,
+        ));
     }
 
     private function answerQuestion(Question $question, Candidate $candidate): void

--- a/tests/Repository/QuizCandidateRepositoryTest.php
+++ b/tests/Repository/QuizCandidateRepositoryTest.php
@@ -33,7 +33,7 @@ final class QuizCandidateRepositoryTest extends DatabaseTestCase
         $this->assertFalse($result);
     }
 
-    public function testSetCorrectionsForCandidateUpdatesCandidateCorrectly(): void
+    public function testSetResultForCandidateUpdatesCandidateCorrectly(): void
     {
         $krtekSeason = $this->getSeasonByCode('krtek');
         $candidate = $this->getCandidateBySeasonAndName($krtekSeason, 'Myrthe');
@@ -42,8 +42,8 @@ final class QuizCandidateRepositoryTest extends DatabaseTestCase
 
         $this->quizCandidateRepository->createIfNotExist($quiz, $candidate);
 
-        $this->quizCandidateRepository->setCorrectionsForCandidate(
-            $quiz, $candidate, 3.5,
+        $this->quizCandidateRepository->setResultForCandidate(
+            $quiz, $candidate, 3.5, 30,
         );
 
         $quizCandidate = $this->quizCandidateRepository->findOneBy([
@@ -54,9 +54,10 @@ final class QuizCandidateRepositoryTest extends DatabaseTestCase
         $this->assertInstanceOf(QuizCandidate::class, $quizCandidate);
 
         $this->assertEqualsWithDelta(3.5, $quizCandidate->corrections, 0.1);
+        $this->assertSame(30, $quizCandidate->penaltySeconds);
     }
 
-    public function testCannotGiveCorrectionsToCandidateWithoutResult(): void
+    public function testCannotGiveResultToCandidateWithoutResult(): void
     {
         $krtekSeason = $this->getSeasonByCode('krtek');
         $candidate = $this->getCandidateBySeasonAndName($krtekSeason, 'Myrthe');
@@ -65,8 +66,8 @@ final class QuizCandidateRepositoryTest extends DatabaseTestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
-        $this->quizCandidateRepository->setCorrectionsForCandidate(
-            $quiz, $candidate, 3.5,
+        $this->quizCandidateRepository->setResultForCandidate(
+            $quiz, $candidate, 3.5, 30,
         );
     }
 }

--- a/tests/Repository/QuizRepositoryTest.php
+++ b/tests/Repository/QuizRepositoryTest.php
@@ -48,7 +48,7 @@ final class QuizRepositoryTest extends DatabaseTestCase
 
         $this->entityManager->refresh($krtekSeason);
 
-        $this->assertCount(1, $krtekSeason->quizzes);
+        $this->assertCount(4, $krtekSeason->quizzes);
     }
 
     public function testTimeForCandidate(): void

--- a/tests/Repository/QuizRepositoryTest.php
+++ b/tests/Repository/QuizRepositoryTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Tvdt\Tests\Repository;
 
+use Doctrine\ORM\PersistentCollection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\MockClock;
 use Tvdt\Entity\Answer;
+use Tvdt\Entity\Candidate;
 use Tvdt\Entity\GivenAnswer;
 use Tvdt\Entity\Question;
 use Tvdt\Entity\Quiz;
@@ -172,6 +174,43 @@ final class QuizRepositoryTest extends DatabaseTestCase
         $result = $this->quizRepository->getScores($quiz);
 
         $this->assertEqualsWithDelta(7.0, $result[0]->score, \PHP_FLOAT_EPSILON);
+    }
+
+    public function testFetchWithQuestionsAndCandidatesEagerLoadsAllBranches(): void
+    {
+        $krtekSeason = $this->getSeasonByCode('krtek');
+        $quiz = $krtekSeason->quizzes->first();
+        $this->assertInstanceOf(Quiz::class, $quiz);
+
+        $candidate = $this->getCandidateBySeasonAndName($krtekSeason, 'Iris');
+        $candidateId = $candidate->id->toString();
+        $question = $quiz->questions->first();
+        $this->assertInstanceOf(Question::class, $question);
+        $answer = $question->answers->first();
+        $this->assertInstanceOf(Answer::class, $answer);
+        $answer->addCandidate($candidate);
+
+        $quizCandidate = new QuizCandidate($quiz, $candidate);
+        $this->entityManager->persist($quizCandidate);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $fetched = $this->quizRepository->fetchWithQuestionsAndCandidates($quiz->id);
+
+        $this->assertInstanceOf(PersistentCollection::class, $fetched->questions);
+        $this->assertTrue($fetched->questions->isInitialized());
+
+        $fetchedAnswer = $fetched->questions->first()->answers->first();
+        $this->assertInstanceOf(PersistentCollection::class, $fetchedAnswer->candidates);
+        $this->assertTrue($fetchedAnswer->candidates->isInitialized());
+        $this->assertTrue($fetchedAnswer->candidates->exists(
+            static fn (int $key, Candidate $c): bool => $c->id->toString() === $candidateId,
+        ));
+
+        $this->assertInstanceOf(PersistentCollection::class, $fetched->candidateData);
+        $this->assertTrue($fetched->candidateData->isInitialized());
+        $this->assertCount(1, $fetched->candidateData);
+        $this->assertSame($candidateId, $fetched->candidateData->first()->candidate->id->toString());
     }
 
     public function testCandidatesWithSameScoreAreSortedCorrectlyByTime(): void

--- a/tests/Repository/UserRepositoryTest.php
+++ b/tests/Repository/UserRepositoryTest.php
@@ -13,6 +13,7 @@ use Tvdt\Entity\GivenAnswer;
 use Tvdt\Entity\Question;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\QuizCandidate;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Repository\UserRepository;
 
 use function PHPUnit\Framework\assertEmpty;
@@ -78,7 +79,7 @@ final class UserRepositoryTest extends DatabaseTestCase
         $this->entityManager->persist($givenAnswer);
 
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Vera' => Elimination::SCREEN_GREEN];
+        $elimination->data = ['Vera' => ScreenColour::Green->value];
 
         $this->entityManager->persist($elimination);
 

--- a/tests/Service/DataExportServiceTest.php
+++ b/tests/Service/DataExportServiceTest.php
@@ -17,6 +17,7 @@ use Tvdt\Entity\Question;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\QuizCandidate;
 use Tvdt\Entity\User;
+use Tvdt\Enum\ScreenColour;
 use Tvdt\Service\DataExportService;
 use Tvdt\Tests\Repository\DatabaseTestCase;
 
@@ -295,11 +296,11 @@ final class DataExportServiceTest extends DatabaseTestCase
         $claudia = $this->getCandidateBySeasonAndName($season, 'Claudia');
 
         $elimination = new Elimination($quiz);
-        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN, 'Claudia' => Elimination::SCREEN_RED];
+        $elimination->data = ['Tom' => ScreenColour::Green->value, 'Claudia' => ScreenColour::Red->value];
 
         $this->entityManager->persist($elimination);
-        $this->entityManager->persist(new EliminationScreenView($elimination, $tom, Elimination::SCREEN_GREEN));
-        $this->entityManager->persist(new EliminationScreenView($elimination, $claudia, Elimination::SCREEN_RED));
+        $this->entityManager->persist(new EliminationScreenView($elimination, $tom, ScreenColour::Green));
+        $this->entityManager->persist(new EliminationScreenView($elimination, $claudia, ScreenColour::Red));
         $this->entityManager->flush();
         $this->entityManager->clear();
 

--- a/tests/Service/DataExportServiceTest.php
+++ b/tests/Service/DataExportServiceTest.php
@@ -10,6 +10,8 @@ use PhpOffice\PhpSpreadsheet\Reader;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Tvdt\Entity\Answer;
+use Tvdt\Entity\Elimination;
+use Tvdt\Entity\EliminationScreenView;
 use Tvdt\Entity\GivenAnswer;
 use Tvdt\Entity\Question;
 use Tvdt\Entity\Quiz;
@@ -77,7 +79,7 @@ final class DataExportServiceTest extends DatabaseTestCase
 
         $quizContent = $zip->getFromName('krtek-Krtek-Weekend/Quiz-1.xlsx');
         $this->assertIsString($quizContent);
-        $this->assertSame(['Quiz info', 'Questions', 'Raw answers', 'Results', 'Eliminations'], $this->sheetNames($quizContent));
+        $this->assertSame(['Quiz info', 'Questions', 'Raw answers', 'Results', 'Eliminations', 'Elimination screen views'], $this->sheetNames($quizContent));
 
         $candidatesContent = $zip->getFromName('krtek-Krtek-Weekend/candidates.xlsx');
         $this->assertIsString($candidatesContent);
@@ -282,6 +284,43 @@ final class DataExportServiceTest extends DatabaseTestCase
 
         $this->assertTrue($sheet->getStyle($column.$correctRowNumber)->getFont()->getBold(), 'Expected the correct answer to be bold');
         $this->assertFalse($sheet->getStyle($column.$wrongRowNumber)->getFont()->getBold(), 'Expected the wrong answer to not be bold');
+    }
+
+    public function testEliminationScreenViewsSheetShowsCandidateColourAndOrder(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $quiz = $this->entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Quiz 1', 'season' => $season]);
+        $this->assertInstanceOf(Quiz::class, $quiz);
+        $tom = $this->getCandidateBySeasonAndName($season, 'Tom');
+        $claudia = $this->getCandidateBySeasonAndName($season, 'Claudia');
+
+        $elimination = new Elimination($quiz);
+        $elimination->data = ['Tom' => Elimination::SCREEN_GREEN, 'Claudia' => Elimination::SCREEN_RED];
+
+        $this->entityManager->persist($elimination);
+        $this->entityManager->persist(new EliminationScreenView($elimination, $tom, Elimination::SCREEN_GREEN));
+        $this->entityManager->persist(new EliminationScreenView($elimination, $claudia, Elimination::SCREEN_RED));
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $zip = $this->openZip($this->getUserByEmail('user2@example.org'));
+        $quizContent = $zip->getFromName('krtek-Krtek-Weekend/Quiz-1.xlsx');
+        $this->assertIsString($quizContent);
+        $zip->close();
+
+        $rows = $this->loadSheet($quizContent, 'Elimination screen views')->toArray();
+        $header = $rows[0];
+        $dataRows = \array_slice($rows, 1);
+
+        $candidateIndex = array_search('Candidate', $header, true);
+        $colourIndex = array_search('Colour', $header, true);
+        $this->assertIsInt($candidateIndex);
+        $this->assertIsInt($colourIndex);
+
+        $this->assertSame('Tom', $dataRows[0][$candidateIndex]);
+        $this->assertSame('green', $dataRows[0][$colourIndex]);
+        $this->assertSame('Claudia', $dataRows[1][$candidateIndex]);
+        $this->assertSame('red', $dataRows[1][$colourIndex]);
     }
 
     public function testQuizInfoSheetShowsDropoutsFinalizationAndDisabledQuestions(): void

--- a/tests/Service/DataExportServiceTest.php
+++ b/tests/Service/DataExportServiceTest.php
@@ -109,7 +109,7 @@ final class DataExportServiceTest extends DatabaseTestCase
         $labelsIndex = array_search('Labels', $header, true);
         $usedInQuizzesIndex = array_search('Used in quizzes', $header, true);
 
-        $reusableRow = current(array_filter($dataRows, static fn (array $row): bool => 'Wie is de Krtek?' === $row[$questionIndex]));
+        $reusableRow = current(array_filter($dataRows, static fn (array $row): bool => 'Wat is de bijnaam van de Krtek?' === $row[$questionIndex]));
         $this->assertIsArray($reusableRow);
         $this->assertSame('Yes', $reusableRow[$reusableIndex]);
         $this->assertSame('Finale', $reusableRow[$labelsIndex]);

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -202,6 +202,7 @@ Reusable: Herbruikbaar
 Save: Opslaan
 'Save and start elimination': 'Opslaan en eliminatie starten'
 Score: Score
+'Screens shown': 'Getoonde schermen'
 Season: Seizoen
 'Season Code': Seizoencode
 'Season Name': Seizoennaam
@@ -211,6 +212,7 @@ Seasons: Seizoenen
 'Send password reset email': 'Stuur reset-e-mail'
 Settings: Instellingen
 'Show Numbers': 'Toon nummers'
+'Shown at': 'Getoond om'
 'Sign in': 'Log in'
 Soon™: Soon™
 'Sort A–Z': 'Sorteer A-Z'

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -85,6 +85,8 @@ Draft: Concept
 EMPTY: LEEG
 Edit: Bewerken
 'Edit question': 'Vraag bewerken'
+'Elimination deleted': 'Eliminatie verwijderd'
+'Elimination updated': 'Eliminatie bijgewerkt'
 Email: E-mail
 'Enter name': 'Voer een naam in'
 'Enter your email address, and we will send you a link to reset your password.': 'Voer je e-mailadres in en we sturen je een link om je wachtwoord te resetten.'

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -24,6 +24,7 @@ All: Alle
 'Answer Mapping': 'Antwoord-kandidaat koppeling'
 'Are you sure you want to clear all the results? This will also delete all the eliminations.': 'Weet je zeker dat je de resultaten wilt leegmaken? Dit gooit ook alle eliminaties weg.'
 'Are you sure you want to delete this candidate? All their answers will be lost.': 'Weet je zeker dat je deze kandidaat wilt verwijderen? Alle gegeven antwoorden gaan dan verloren.'
+'Are you sure you want to delete this elimination?': 'Weet je zeker dat je deze eliminatie wilt verwijderen?'
 'Are you sure you want to delete this question from the question bank?': 'Weet je zeker dat je deze vraag uit de vragenbank wilt verwijderen?'
 'Are you sure you want to delete this quiz?': 'Weet je zeker dat je deze test wilt verwijderen?'
 'Are you sure you want to reset progress for this candidate? Their given answers for this quiz will be deleted.': 'Weet je zeker dat je de voortgang van deze kandidaat wilt resetten? De ingevulde antwoorden voor deze test worden verwijderd.'
@@ -74,6 +75,7 @@ Delete: Verwijderen
 'Delete Quiz...': 'Test verwijderen...'
 'Delete account': 'Account verwijderen'
 'Delete account...': 'Account verwijderen...'
+Delete...: Verwijderen...
 'Deleting your account also deletes every season you are the only owner of. This cannot be undone.': 'Als je je account verwijdert, worden ook alle seizoenen verwijderd waarvan jij de enige eigenaar bent. Dit kan niet ongedaan worden gemaakt.'
 'Download Template': 'Download sjabloon'
 'Download an archive of everything stored under your account: your profile, the seasons you own, their quizzes, results and candidates.': 'Download een archief met alles wat onder je account is opgeslagen: je profiel, de seizoenen die je bezit, met de bijbehorende testen, resultaten en kandidaten.'


### PR DESCRIPTION
## Summary
- Closes #19: adds a "Delete..." button (with confirm modal) to the prepare-elimination page, since multiple eliminations can exist per quiz with no way to clean up an unwanted one.
- Closes #98: records which candidate's screen was shown, in what order and with what colour (`EliminationScreenView`), and shows it as a log table on the prepare-elimination page. Colour is snapshotted at view time since it can be edited on the elimination afterwards, and ordering uses the row id (a time-ordered UUIDv7) rather than the second-precision timestamp so simultaneous views still sort correctly.
- Widens the quiz overview page's two-column breakpoint from `md` to `xl` — the question list was cramped and wrapping against the help panel on common laptop widths.
- Adds realistic dev-only demo data: quiz 1 fully played out with randomized answers/timings, quiz 2 finalized and active, `confirmAnswers` disabled, and a `krtek@tijdvoordetest.nl` owner account. Lives in `DevFixtures` (dependent on `KrtekFixtures`) so the test database and its ~26 dependent tests are untouched.
- Combines the separate Jokers/Straftijd forms on the quiz results page into one form/button per candidate, makes the dropout count editable, and switches save buttons to an icon-only floppy disk with a hover tooltip.
- Shows each candidate's score and time on the prepare-elimination page, ordered the same way as the results tab, and colour-codes the colour `<select>` to match its own selected value (pure CSS, no JS).
- Matches the elimination "enter name" screen to the quiz one: narrow centered form, and the Backoffice/Logout buttons are now always hidden on both the enter-name and colour-reveal screens since these are projected during a live show, not admin pages.
- Adds an "Elimination screen views" tab to the per-quiz XLSX export, listing every screen shown (candidate, colour, order) alongside the existing Eliminations tab.
- Fixes a cartesian-product query that was slowing the quiz overview page down to ~2.8s: `QuizRepository::fetchWithQuestionsAndCandidates()` joined three independent to-many collections in one query, multiplying rather than summing their row counts (~14,000 rows for a 15-question/13-candidate quiz). Split into two lean queries, dropped an unused join, removed a dead computation, and gave `candidates_question()` its own scoped eager-load method instead of reusing the same overloaded query. Brings the page down to ~250ms.
- Reorders the prepare-elimination layout: the "Screens shown" table sits under the help text on the right column at desktop width, and on mobile the stacked order is candidate form → screens table → help text (via responsive Bootstrap order/offset utilities, no DOM reshuffling).

## Test plan
- [x] `just test` — full suite green (313 tests)
- [x] `just phpstan`, `just fix-cs`, `just rector --dry-run` — all clean
- [x] `just translations` — no uncommitted diff after generation
- [x] Manually verified in browser: delete modal, screen-view log, combined result form, editable dropouts, prepare-elimination ordering/colours, elimination enter-name and colour-reveal screens, quiz overview page load time (profiler: ~2.8s → ~250ms), and the prepare-elimination responsive layout at desktop and mobile widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Screens shown” history for elimination preparation.
  * Added an “Elimination screen views” worksheet to quiz exports.
  * Added backoffice elimination deletion with confirmation and permission checks.
* **UI Updates**
  * Added a deletion button + confirmation modal, and updated the elimination preparation screen layout and colouring UI.
  * Consolidated quiz result editing into a single form and introduced a dedicated dropouts save action.
* **Documentation**
  * Updated Dutch UI labels for deletion and screen-history display.
* **Tests**
  * Expanded coverage for screen-view logging, candidate ordering, and elimination deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->