### PR TITLE
Feature/229 quiz status

### DIFF
--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -25,7 +25,7 @@
         tests/Unit: plain PHPUnit TestCase, no kernel, DB, or browser. Fast, no I/O.
         tests/Integration: KernelTestCase/WebTestCase-based (DB, routing, the container). DAMA
         rolls back each test's transaction, so these stay isolated and fast enough for every run.
-        tests/E2E: Symfony Panther driving a real Chromium browser. Runs in a separate process
+        tests/E2E: Symfony Panther driving a real Firefox browser. Runs in a separate process
         DAMA can't wrap, so it's kept out of the default suite, run explicitly with `just test-e2e`.
         "default" is unit+integration together and is what bare `just test` runs; passing an
         explicit testsuite, file, or directory argument to phpunit overrides this.

--- a/tests/E2E/AbstractE2ETestCase.php
+++ b/tests/E2E/AbstractE2ETestCase.php
@@ -6,6 +6,7 @@ namespace Tvdt\Tests\E2E;
 
 use Symfony\Component\Panther\Client;
 use Symfony\Component\Panther\PantherTestCase;
+use Tvdt\DataFixtures\TestFixtures;
 
 abstract class AbstractE2ETestCase extends PantherTestCase
 {
@@ -15,7 +16,7 @@ abstract class AbstractE2ETestCase extends PantherTestCase
 
         $form = $client->getCrawler()->filter('form')->form([
             '_username' => 'krtek-admin@example.org',
-            '_password' => 'test1234',
+            '_password' => TestFixtures::PASSWORD,
         ]);
         $client->submit($form);
         $client->waitFor('a[href="/logout"]');

--- a/tests/Integration/Controller/Backoffice/QuizRenameTest.php
+++ b/tests/Integration/Controller/Backoffice/QuizRenameTest.php
@@ -88,4 +88,23 @@ final class QuizRenameTest extends AbstractControllerWebTestCase
         $this->entityManager->clear();
         $this->assertSame('Quiz 2', $this->getQuizByName('Quiz 2')->name);
     }
+
+    public function testRenameIsDeniedForNonOwner(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 2');
+
+        $token = $this->getCsrfTokenFromOverview($quiz, '/rename');
+
+        $this->loginAs('test@example.org');
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/rename', $quiz->id), [
+            '_token' => $token,
+            'name' => 'Hijacked Quiz',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+
+        $this->entityManager->clear();
+        $this->assertSame('Quiz 2', $this->getQuizByName('Quiz 2')->name);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backoffice users can rename quizzes and seasons with validation and duplicate-name protection.
  * Quiz pages now show clearer progression statuses, including New, Active, Finished, Done and Revealed.
  * Added rename controls and modals to relevant backoffice pages.
  * Added browser-based coverage for quiz editing, renaming, login links and elimination screens.

* **Bug Fixes**
  * Improved unsaved-form protection so edited modals are not accidentally dismissed.

* **Documentation**
  * Added guidance for configuring dirty-state tracking on backoffice forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->