### PR TITLE
Fix stuck answer highlight on mobile after Turbo page refresh

### DIFF
--- a/templates/quiz/base.html.twig
+++ b/templates/quiz/base.html.twig
@@ -1,4 +1,5 @@
 {% extends 'base.html.twig' %}
+{% block head_extra %}<meta name="turbo-refresh-method" content="replace">{% endblock %}
 {% block importmap %}{{ importmap('quiz') }}{% endblock %}
 {% block nav %}{{ include('quiz/nav.html.twig') }}{% endblock %}
 {% block main %}


### PR DESCRIPTION
## Summary
- Without confirm mode, answering a quiz question redirects back to the same URL, which Turbo 8 treats as a "page refresh" and morphs the DOM instead of doing a full replace.
- The morph reuses the tapped answer button's DOM node (with its `:focus`/`:hover` style) at the same position for the next question, so the previously-tapped option stays highlighted green.
- Opt out of morphing on quiz pages via `<meta name="turbo-refresh-method" content="replace">` so each question renders with fresh elements.

Fixes #126

## Test plan
- [x] `bin/console lint:twig templates/quiz/base.html.twig`
- [x] `vendor/bin/twig-cs-fixer lint templates/quiz/base.html.twig`
- [x] Verified the meta tag renders in served HTML
- [ ] Manually verify on a real mobile device / touch emulator that the highlight no longer sticks to the next question