### PR TITLE
Add season ownership management and danger zone

### DIFF
--- a/assets/controllers/bo/type_to_confirm_controller.ts
+++ b/assets/controllers/bo/type_to_confirm_controller.ts
@@ -1,0 +1,20 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['input', 'submit'];
+    static values = { word: String };
+
+    declare readonly inputTarget: HTMLInputElement;
+    declare readonly submitTarget: HTMLButtonElement;
+    declare readonly wordValue: string;
+
+    connect(): void {
+        this.check();
+    }
+
+    check(): void {
+        this.submitTarget.disabled =
+            this.inputTarget.value.trim().toLowerCase() !==
+                this.wordValue.toLowerCase();
+    }
+}

--- a/assets/controllers/bo/type_to_confirm_controller.ts
+++ b/assets/controllers/bo/type_to_confirm_controller.ts
@@ -2,19 +2,20 @@ import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
     static targets = ['input', 'submit'];
-    static values = { word: String };
+    static values = { words: Array };
 
     declare readonly inputTarget: HTMLInputElement;
     declare readonly submitTarget: HTMLButtonElement;
-    declare readonly wordValue: string;
+    declare readonly wordsValue: string[];
 
     connect(): void {
         this.check();
     }
 
     check(): void {
-        this.submitTarget.disabled =
-            this.inputTarget.value.trim().toLowerCase() !==
-                this.wordValue.toLowerCase();
+        const value = this.inputTarget.value.trim().toLowerCase();
+        this.submitTarget.disabled = !this.wordsValue.some(
+            (word) => word.toLowerCase() === value,
+        );
     }
 }

--- a/assets/controllers/bo/type_to_confirm_controller_test.ts
+++ b/assets/controllers/bo/type_to_confirm_controller_test.ts
@@ -1,0 +1,49 @@
+import { assertEquals } from '@std/assert';
+
+const { default: TypeToConfirmController } = await import(
+    './type_to_confirm_controller.ts'
+);
+
+// deno-lint-ignore no-explicit-any
+function makeController(word: string, value: string): any {
+    const controller = new TypeToConfirmController({} as never);
+    return Object.assign(controller, {
+        inputTarget: { value },
+        submitTarget: { disabled: false },
+        wordValue: word,
+    });
+}
+
+Deno.test('check() disables the submit button when the input does not match', () => {
+    const controller = makeController('verwijderen', '');
+    controller.check();
+    assertEquals(controller.submitTarget.disabled, true);
+});
+
+Deno.test('check() enables the submit button on an exact match', () => {
+    const controller = makeController('verwijderen', 'verwijderen');
+    controller.check();
+    assertEquals(controller.submitTarget.disabled, false);
+});
+
+Deno.test('check() is case-insensitive and ignores surrounding whitespace', () => {
+    const controller = makeController('verwijderen', '  Verwijderen  ');
+    controller.check();
+    assertEquals(controller.submitTarget.disabled, false);
+});
+
+Deno.test('check() disables the submit button again once the input no longer matches', () => {
+    const controller = makeController('verwijderen', 'verwijderen');
+    controller.check();
+    assertEquals(controller.submitTarget.disabled, false);
+
+    controller.inputTarget.value = 'verwijdere';
+    controller.check();
+    assertEquals(controller.submitTarget.disabled, true);
+});
+
+Deno.test('connect() disables the submit button by default', () => {
+    const controller = makeController('verwijderen', '');
+    controller.connect();
+    assertEquals(controller.submitTarget.disabled, true);
+});

--- a/assets/controllers/bo/type_to_confirm_controller_test.ts
+++ b/assets/controllers/bo/type_to_confirm_controller_test.ts
@@ -5,45 +5,51 @@ const { default: TypeToConfirmController } = await import(
 );
 
 // deno-lint-ignore no-explicit-any
-function makeController(word: string, value: string): any {
+function makeController(words: string[], value: string): any {
     const controller = new TypeToConfirmController({} as never);
     return Object.assign(controller, {
         inputTarget: { value },
         submitTarget: { disabled: false },
-        wordValue: word,
+        wordsValue: words,
     });
 }
 
-Deno.test('check() disables the submit button when the input does not match', () => {
-    const controller = makeController('verwijderen', '');
+Deno.test('check() disables the submit button when the input matches none of the words', () => {
+    const controller = makeController(['verwijderen', 'delete'], '');
     controller.check();
     assertEquals(controller.submitTarget.disabled, true);
 });
 
-Deno.test('check() enables the submit button on an exact match', () => {
-    const controller = makeController('verwijderen', 'verwijderen');
+Deno.test('check() enables the submit button on an exact match of the first word', () => {
+    const controller = makeController(['verwijderen', 'delete'], 'verwijderen');
+    controller.check();
+    assertEquals(controller.submitTarget.disabled, false);
+});
+
+Deno.test('check() enables the submit button on an exact match of another accepted word', () => {
+    const controller = makeController(['verwijderen', 'delete'], 'delete');
     controller.check();
     assertEquals(controller.submitTarget.disabled, false);
 });
 
 Deno.test('check() is case-insensitive and ignores surrounding whitespace', () => {
-    const controller = makeController('verwijderen', '  Verwijderen  ');
+    const controller = makeController(['verwijderen', 'delete'], '  Delete  ');
     controller.check();
     assertEquals(controller.submitTarget.disabled, false);
 });
 
 Deno.test('check() disables the submit button again once the input no longer matches', () => {
-    const controller = makeController('verwijderen', 'verwijderen');
+    const controller = makeController(['verwijderen', 'delete'], 'delete');
     controller.check();
     assertEquals(controller.submitTarget.disabled, false);
 
-    controller.inputTarget.value = 'verwijdere';
+    controller.inputTarget.value = 'delet';
     controller.check();
     assertEquals(controller.submitTarget.disabled, true);
 });
 
 Deno.test('connect() disables the submit button by default', () => {
-    const controller = makeController('verwijderen', '');
+    const controller = makeController(['verwijderen', 'delete'], '');
     controller.connect();
     assertEquals(controller.submitTarget.disabled, true);
 });

--- a/migrations/Version20260724165751.php
+++ b/migrations/Version20260724165751.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/** Auto-generated Migration: Please modify to your needs! */
+final class Version20260724165751 extends AbstractMigration
+{
+    #[\Override]
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE season ADD deleted_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+    }
+
+    #[\Override]
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE season DROP deleted_at');
+    }
+}

--- a/src/Controller/Backoffice/QuizController.php
+++ b/src/Controller/Backoffice/QuizController.php
@@ -53,6 +53,8 @@ class QuizController extends AbstractController
     )]
     public function index(Season $season, Quiz $quiz): Response
     {
+        $this->assertQuizInSeason($season, $quiz);
+
         return $this->redirectToRoute('tvdt_backoffice_quiz_overview', ['seasonCode' => $season->seasonCode, 'quiz' => $quiz->id]);
     }
 
@@ -64,6 +66,8 @@ class QuizController extends AbstractController
     )]
     public function overview(Season $season, Quiz $quiz): Response
     {
+        $this->assertQuizInSeason($season, $quiz);
+
         $fetchedQuiz = $this->quizRepository->fetchWithQuestionsAndCandidates($quiz->id);
 
         return $this->render('backoffice/quiz.html.twig', [
@@ -83,6 +87,8 @@ class QuizController extends AbstractController
     )]
     public function result(Season $season, Quiz $quiz): Response
     {
+        $this->assertQuizInSeason($season, $quiz);
+
         $fetchedQuiz = $this->quizRepository->fetchWithQuestions($quiz->id);
 
         return $this->render('backoffice/quiz.html.twig', [
@@ -102,6 +108,8 @@ class QuizController extends AbstractController
     )]
     public function candidatesTab(Season $season, Quiz $quiz): Response
     {
+        $this->assertQuizInSeason($season, $quiz);
+
         $candidateData = $this->buildCandidateData($season, $quiz, $quiz->candidateData);
 
         return $this->render('backoffice/quiz.html.twig', [
@@ -121,6 +129,8 @@ class QuizController extends AbstractController
     )]
     public function answerMapping(Season $season, Quiz $quiz): Response
     {
+        $this->assertQuizInSeason($season, $quiz);
+
         $fetchedQuiz = $this->quizRepository->fetchWithQuestions($quiz->id);
 
         if ($fetchedQuiz->questions->isEmpty()) {
@@ -235,6 +245,10 @@ class QuizController extends AbstractController
     )]
     public function enableQuiz(Season $season, ?Quiz $quiz, Request $request): RedirectResponse
     {
+        if ($quiz instanceof Quiz && $quiz->season !== $season) {
+            throw new BadRequestHttpException('Invalid quiz');
+        }
+
         if ($quiz instanceof Quiz && !$quiz->isFinalized) {
             $this->addFlash(FlashType::Danger, $this->translator->trans('The quiz must be finalized before it can be activated'));
 
@@ -386,6 +400,8 @@ class QuizController extends AbstractController
     )]
     public function modifyResult(Quiz $quiz, Candidate $candidate, Request $request): RedirectResponse
     {
+        $this->assertCandidateInQuizSeason($quiz, $candidate);
+
         $corrections = (float) $request->request->get('corrections');
         $penalty = (int) $request->request->get('penalty');
 
@@ -420,6 +436,8 @@ class QuizController extends AbstractController
     )]
     public function toggleCandidate(Quiz $quiz, Candidate $candidate): RedirectResponse
     {
+        $this->assertCandidateInQuizSeason($quiz, $candidate);
+
         $quizCandidate = $this->quizCandidateRepository->findOneBy([
             'quiz' => $quiz,
             'candidate' => $candidate,
@@ -451,6 +469,8 @@ class QuizController extends AbstractController
     )]
     public function resetCandidateProgress(Quiz $quiz, Candidate $candidate): RedirectResponse
     {
+        $this->assertCandidateInQuizSeason($quiz, $candidate);
+
         $this->em->wrapInTransaction(function () use ($quiz, $candidate): void {
             $this->givenAnswerRepository->deleteAllForCandidateInQuiz($quiz, $candidate);
             $this->quizCandidateRepository->resetProgressForCandidate($quiz, $candidate);
@@ -459,6 +479,20 @@ class QuizController extends AbstractController
         $this->addFlash(FlashType::Success, $this->translator->trans('Candidate progress reset'));
 
         return $this->redirectToRoute('tvdt_backoffice_quiz_candidates_tab', ['seasonCode' => $quiz->season->seasonCode, 'quiz' => $quiz->id]);
+    }
+
+    private function assertQuizInSeason(Season $season, Quiz $quiz): void
+    {
+        if (false === $season->quizzes->contains($quiz)) {
+            throw new BadRequestHttpException('Invalid quiz');
+        }
+    }
+
+    private function assertCandidateInQuizSeason(Quiz $quiz, Candidate $candidate): void
+    {
+        if (false === $quiz->season->candidates->contains($candidate)) {
+            throw new BadRequestHttpException('Invalid candidate');
+        }
     }
 
     /**

--- a/src/Controller/Backoffice/SeasonController.php
+++ b/src/Controller/Backoffice/SeasonController.php
@@ -6,6 +6,7 @@ namespace Tvdt\Controller\Backoffice;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
+use Safe\DateTime;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormError;
@@ -32,7 +33,6 @@ use Tvdt\Form\SettingsForm;
 use Tvdt\Form\UploadQuizFormType;
 use Tvdt\Repository\CandidateRepository;
 use Tvdt\Repository\QuizRepository;
-use Tvdt\Repository\SeasonRepository;
 use Tvdt\Repository\UserRepository;
 use Tvdt\Security\Voter\SeasonVoter;
 use Tvdt\Service\QuizSpreadsheetService;
@@ -48,7 +48,6 @@ class SeasonController extends AbstractController
         private readonly CandidateRepository $candidateRepository,
         private readonly QuizRepository $quizRepository,
         private readonly UserRepository $userRepository,
-        private readonly SeasonRepository $seasonRepository,
     ) {}
 
     #[IsGranted(SeasonVoter::EDIT, subject: 'season')]
@@ -206,13 +205,18 @@ class SeasonController extends AbstractController
     {
         $confirmation = mb_strtolower(mb_trim($request->request->getString('confirmation')));
 
-        if ('verwijderen' !== $confirmation) {
-            $this->addFlash(FlashType::Danger, $this->translator->trans("Type 'verwijderen' to confirm"));
+        if (!\in_array($confirmation, ['verwijderen', 'delete'], true)) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('Type delete to confirm'));
 
             return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
         }
 
-        $this->seasonRepository->deleteSeason($season);
+        // Soft delete only: this hides the season everywhere without touching its tests,
+        // candidates, or answers, so it can still be restored later (see issue for restoring a
+        // soft-deleted season). Permanent removal only happens via GDPR account deletion
+        // (UserRepository::deleteUser()) or the scheduled cleanup job (see issue for that).
+        $season->setDeletedAt(new DateTime());
+        $this->em->flush();
 
         $this->addFlash(FlashType::Success, $this->translator->trans('Season deleted'));
 

--- a/src/Controller/Backoffice/SeasonController.php
+++ b/src/Controller/Backoffice/SeasonController.php
@@ -25,12 +25,15 @@ use Tvdt\Controller\AbstractController;
 use Tvdt\Entity\Candidate;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
+use Tvdt\Entity\User;
 use Tvdt\Enum\FlashType;
 use Tvdt\Form\AddCandidatesFormType;
 use Tvdt\Form\SettingsForm;
 use Tvdt\Form\UploadQuizFormType;
 use Tvdt\Repository\CandidateRepository;
 use Tvdt\Repository\QuizRepository;
+use Tvdt\Repository\SeasonRepository;
+use Tvdt\Repository\UserRepository;
 use Tvdt\Security\Voter\SeasonVoter;
 use Tvdt\Service\QuizSpreadsheetService;
 
@@ -44,6 +47,8 @@ class SeasonController extends AbstractController
         private readonly QuizSpreadsheetService $quizSpreadsheet,
         private readonly CandidateRepository $candidateRepository,
         private readonly QuizRepository $quizRepository,
+        private readonly UserRepository $userRepository,
+        private readonly SeasonRepository $seasonRepository,
     ) {}
 
     #[IsGranted(SeasonVoter::EDIT, subject: 'season')]
@@ -122,6 +127,96 @@ class SeasonController extends AbstractController
         $this->addFlash(FlashType::Success, $this->translator->trans('Season code regenerated'));
 
         return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
+    }
+
+    #[IsCsrfTokenValid('add_season_owner')]
+    #[IsGranted(SeasonVoter::EDIT, subject: 'season')]
+    #[Route(
+        '/backoffice/season/{seasonCode:season}/settings/add-owner',
+        name: 'tvdt_backoffice_season_add_owner',
+        requirements: ['seasonCode' => self::SEASON_CODE_REGEX],
+        methods: ['POST'],
+    )]
+    public function addOwner(Season $season, Request $request): RedirectResponse
+    {
+        $email = $request->request->getString('email');
+        $user = $this->userRepository->findOneBy(['email' => $email]);
+
+        if (!$user instanceof User) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('No user found with this email address'));
+
+            return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
+        }
+
+        if ($season->isOwner($user)) {
+            $this->addFlash(FlashType::Info, $this->translator->trans('This user is already an owner of this season'));
+
+            return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
+        }
+
+        $season->addOwner($user);
+        $this->em->flush();
+
+        $this->addFlash(FlashType::Success, $this->translator->trans('Owner added'));
+
+        return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
+    }
+
+    #[IsCsrfTokenValid('remove_season_owner')]
+    #[IsGranted(SeasonVoter::EDIT, subject: 'season')]
+    #[Route(
+        '/backoffice/season/{seasonCode:season}/settings/owner/{owner}/remove',
+        name: 'tvdt_backoffice_season_remove_owner',
+        requirements: ['seasonCode' => self::SEASON_CODE_REGEX, 'owner' => Requirement::UUID],
+        methods: ['POST'],
+    )]
+    public function removeOwner(Season $season, User $owner): RedirectResponse
+    {
+        if ($season->owners->count() <= 1) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('Cannot remove the last owner of a season'));
+
+            return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
+        }
+
+        $isSelf = $owner === $this->authenticatedUser;
+
+        $season->removeOwner($owner);
+        $this->em->flush();
+
+        if ($isSelf) {
+            $this->addFlash(FlashType::Success, $this->translator->trans('You left the season'));
+
+            return $this->redirectToRoute('tvdt_backoffice_index');
+        }
+
+        $this->addFlash(FlashType::Success, $this->translator->trans('Owner removed'));
+
+        return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
+    }
+
+    #[IsCsrfTokenValid('delete_season')]
+    #[IsGranted(SeasonVoter::DELETE, subject: 'season')]
+    #[Route(
+        '/backoffice/season/{seasonCode:season}/settings/delete',
+        name: 'tvdt_backoffice_season_delete',
+        requirements: ['seasonCode' => self::SEASON_CODE_REGEX],
+        methods: ['POST'],
+    )]
+    public function deleteSeason(Season $season, Request $request): RedirectResponse
+    {
+        $confirmation = mb_strtolower(mb_trim($request->request->getString('confirmation')));
+
+        if ('verwijderen' !== $confirmation) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans("Type 'verwijderen' to confirm"));
+
+            return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
+        }
+
+        $this->seasonRepository->deleteSeason($season);
+
+        $this->addFlash(FlashType::Success, $this->translator->trans('Season deleted'));
+
+        return $this->redirectToRoute('tvdt_backoffice_index');
     }
 
     #[IsCsrfTokenValid('rename_season')]

--- a/src/Controller/Backoffice/SeasonController.php
+++ b/src/Controller/Backoffice/SeasonController.php
@@ -171,6 +171,12 @@ class SeasonController extends AbstractController
     )]
     public function removeOwner(Season $season, User $owner): RedirectResponse
     {
+        if (!$season->isOwner($owner)) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('This user is not an owner of this season'));
+
+            return $this->redirectToRoute('tvdt_backoffice_season_settings', ['seasonCode' => $season->seasonCode]);
+        }
+
         if ($season->owners->count() <= 1) {
             $this->addFlash(FlashType::Danger, $this->translator->trans('Cannot remove the last owner of a season'));
 

--- a/src/Entity/Season.php
+++ b/src/Entity/Season.php
@@ -7,13 +7,18 @@ namespace Tvdt\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\SoftDeleteable\Traits\SoftDeleteableEntity;
 use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Uid\Uuid;
 use Tvdt\Repository\SeasonRepository;
 
+#[Gedmo\SoftDeleteable]
 #[ORM\Entity(repositoryClass: SeasonRepository::class)]
 class Season
 {
+    use SoftDeleteableEntity;
+
     private const string SEASON_CODE_CHARACTERS = 'bcdfghjklmnpqrstvwxz';
 
     #[ORM\Column(type: UuidType::NAME)]

--- a/src/Helpers/SoftDeleteableFilter.php
+++ b/src/Helpers/SoftDeleteableFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Helpers;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class SoftDeleteableFilter
+{
+    /** Runs $fn with Doctrine's global softdeleteable filter disabled, always re-enabling it afterward. */
+    public static function withDisabled(EntityManagerInterface $em, callable $fn): mixed
+    {
+        $filters = $em->getFilters();
+        $filters->disable('softdeleteable');
+
+        try {
+            return $fn();
+        } finally {
+            $filters->enable('softdeleteable');
+        }
+    }
+}

--- a/src/Repository/SeasonRepository.php
+++ b/src/Repository/SeasonRepository.php
@@ -44,19 +44,18 @@ class SeasonRepository extends ServiceEntityRepository
     }
 
     /** Permanently deletes the season and every row tied to it — including the season itself,
-     * which is Gedmo\SoftDeleteable and would otherwise only get its deletedAt set. Used for GDPR
-     * account-deletion purges, never for the season settings page's own "delete season" action,
-     * which soft-deletes instead (see SeasonController::deleteSeason()). */
+     * which is Gedmo\SoftDeleteable and would otherwise only get its deletedAt set. Used as the
+     * single-season entry point for permanent purges (currently exercised directly by
+     * SeasonRepositoryTest; UserRepository::deleteUser() calls scheduleForRemoval() per season
+     * itself so it can batch several seasons' purges into one flush). Never used for the season
+     * settings page's own "delete season" action, which soft-deletes instead (see
+     * SeasonController::deleteSeason()). */
     public function deleteSeason(Season $season): void
     {
         $em = $this->getEntityManager();
         $em->wrapInTransaction(function () use ($em, $season): void {
             $bankQuestionIds = $this->scheduleForRemoval($em, $season);
-            $this->flushWithoutSoftDeleteListener($em);
-
-            // Gedmo\Loggable writes its own "removed" log entry as part of the flush above, so the
-            // audit-log purge must happen after — purging first would just leave that final row behind.
-            $this->purgeBankQuestionAuditLog($em, $bankQuestionIds);
+            $this->flushAndPurgeBankQuestionAuditLog($em, $bankQuestionIds);
         });
     }
 
@@ -64,7 +63,7 @@ class SeasonRepository extends ServiceEntityRepository
      * Purges Gedmo\SoftDeleteable rows and schedules $season for removal, without flushing — lets
      * a caller batch several seasons' removal into one flush (see UserRepository::deleteUser()).
      * $season itself is also Gedmo\SoftDeleteable, so the caller must flush via
-     * flushWithoutSoftDeleteListener() below, or this permanent deletion becomes just another
+     * flushAndPurgeBankQuestionAuditLog() below, or this permanent deletion becomes just another
      * soft-delete (setting deletedAt) instead.
      *
      * @return list<string> the season's BankQuestion ids, to purge their audit log once flushed
@@ -79,6 +78,21 @@ class SeasonRepository extends ServiceEntityRepository
     }
 
     /**
+     * Flushes (with Gedmo\SoftDeleteableListener temporarily detached, see
+     * flushWithoutSoftDeleteListener() below) and then purges the given BankQuestions' audit log
+     * — combined into one method so the flush-then-purge ordering can't be gotten backwards by a
+     * caller: Gedmo\Loggable writes its own "removed" log entry as part of the flush, so purging
+     * first would just leave that final row behind.
+     *
+     * @param list<string> $bankQuestionIds
+     */
+    public function flushAndPurgeBankQuestionAuditLog(EntityManagerInterface $em, array $bankQuestionIds): void
+    {
+        $this->flushWithoutSoftDeleteListener($em);
+        $this->purgeBankQuestionAuditLog($em, $bankQuestionIds);
+    }
+
+    /**
      * Flushes with Gedmo\SoftDeleteableListener temporarily detached, so a Season scheduled for
      * removal (via scheduleForRemoval() above) is actually deleted instead of merely getting its
      * deletedAt set. This also sidesteps a second Gedmo quirk: its listener calls persist() on
@@ -88,7 +102,7 @@ class SeasonRepository extends ServiceEntityRepository
      * for this one flush restores the plain cascade-delete behavior all of this already relied on
      * before Season became SoftDeleteable.
      */
-    public function flushWithoutSoftDeleteListener(EntityManagerInterface $em): void
+    private function flushWithoutSoftDeleteListener(EntityManagerInterface $em): void
     {
         $eventManager = $em->getEventManager();
         $listeners = array_filter(
@@ -144,7 +158,7 @@ class SeasonRepository extends ServiceEntityRepository
      *
      * @param list<string> $bankQuestionIds
      */
-    public function purgeBankQuestionAuditLog(EntityManagerInterface $em, array $bankQuestionIds): void
+    private function purgeBankQuestionAuditLog(EntityManagerInterface $em, array $bankQuestionIds): void
     {
         if ([] === $bankQuestionIds) {
             return;

--- a/src/Repository/SeasonRepository.php
+++ b/src/Repository/SeasonRepository.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace Tvdt\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Tvdt\Entity\BankQuestion;
+use Tvdt\Entity\Elimination;
+use Tvdt\Entity\GivenAnswer;
+use Tvdt\Entity\QuizCandidate;
 use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
 
@@ -35,5 +40,87 @@ class SeasonRepository extends ServiceEntityRepository
             select s from Tvdt\Entity\Season s where :user member of s.owners order by s.name
             DQL
         )->setParameter('user', $user)->getResult();
+    }
+
+    /** Deletes the season and every row tied to it, including data Gedmo would otherwise only soft-delete. */
+    public function deleteSeason(Season $season): void
+    {
+        $em = $this->getEntityManager();
+        $em->wrapInTransaction(function () use ($em, $season): void {
+            $bankQuestionIds = $this->scheduleForRemoval($em, $season);
+            $em->flush();
+
+            // Gedmo\Loggable writes its own "removed" log entry as part of the flush above, so the
+            // audit-log purge must happen after — purging first would just leave that final row behind.
+            $this->purgeBankQuestionAuditLog($em, $bankQuestionIds);
+        });
+    }
+
+    /**
+     * Purges Gedmo\SoftDeleteable rows and schedules $season for removal, without flushing — lets
+     * a caller batch several seasons' removal into one flush (see UserRepository::deleteUser(),
+     * which combines this with removing the user in a single flush; calling flush() separately
+     * per season there confuses Doctrine's change-set detection for still-managed entities tied
+     * to the bulk-deleted rows above).
+     *
+     * @return list<string> the season's BankQuestion ids, to purge their audit log once flushed
+     */
+    public function scheduleForRemoval(EntityManagerInterface $em, Season $season): array
+    {
+        $this->purgeSoftDeletableData($em, $season);
+        $bankQuestionIds = $this->bankQuestionIds($season);
+        $em->remove($season);
+
+        return $bankQuestionIds;
+    }
+
+    /**
+     * QuizCandidate, GivenAnswer, and Elimination are Gedmo\SoftDeleteable, so cascading their
+     * removal through the season/quiz/candidate relations only sets deletedAt — it never removes
+     * the row. That leaves personal data behind indefinitely and, since Candidate/Answer are hard
+     * deleted via orphanRemoval, it also breaks their foreign keys and rolls back the whole
+     * deletion. Bulk DQL deletes bypass the Gedmo listener and physically remove these rows first.
+     */
+    private function purgeSoftDeletableData(EntityManagerInterface $em, Season $season): void
+    {
+        foreach ([QuizCandidate::class, GivenAnswer::class, Elimination::class] as $class) {
+            $em->createQuery(<<<DQL
+                delete from {$class} e
+                where e.quiz in (select q from Tvdt\Entity\Quiz q where q.season = :season)
+                DQL)
+                ->setParameter('season', $season)
+                ->execute();
+        }
+    }
+
+    /** @return list<string> */
+    private function bankQuestionIds(Season $season): array
+    {
+        return array_values(array_map(
+            static fn (BankQuestion $bankQuestion): string => $bankQuestion->id->toString(),
+            $season->bankQuestions->toArray(),
+        ));
+    }
+
+    /**
+     * Gedmo\Loggable audit rows (ext_log_entries) aren't foreign-keyed to the entity they log —
+     * object_id is a plain string — so removing a BankQuestion never cleans up its history, and
+     * the editor's username/email would otherwise remain in those rows forever.
+     *
+     * @param list<string> $bankQuestionIds
+     */
+    public function purgeBankQuestionAuditLog(EntityManagerInterface $em, array $bankQuestionIds): void
+    {
+        if ([] === $bankQuestionIds) {
+            return;
+        }
+
+        $em->createQuery(<<<'DQL'
+            delete from Tvdt\Entity\LogEntry l
+            where l.objectClass = :class and l.objectId in (:ids)
+            DQL)
+            ->setParameter('class', BankQuestion::class)
+            ->setParameter('ids', $bankQuestionIds)
+            ->execute();
     }
 }

--- a/src/Repository/SeasonRepository.php
+++ b/src/Repository/SeasonRepository.php
@@ -7,6 +7,7 @@ namespace Tvdt\Repository;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Gedmo\SoftDeleteable\SoftDeleteableListener;
 use Tvdt\Entity\BankQuestion;
 use Tvdt\Entity\Elimination;
 use Tvdt\Entity\GivenAnswer;
@@ -42,13 +43,16 @@ class SeasonRepository extends ServiceEntityRepository
         )->setParameter('user', $user)->getResult();
     }
 
-    /** Deletes the season and every row tied to it, including data Gedmo would otherwise only soft-delete. */
+    /** Permanently deletes the season and every row tied to it — including the season itself,
+     * which is Gedmo\SoftDeleteable and would otherwise only get its deletedAt set. Used for GDPR
+     * account-deletion purges, never for the season settings page's own "delete season" action,
+     * which soft-deletes instead (see SeasonController::deleteSeason()). */
     public function deleteSeason(Season $season): void
     {
         $em = $this->getEntityManager();
         $em->wrapInTransaction(function () use ($em, $season): void {
             $bankQuestionIds = $this->scheduleForRemoval($em, $season);
-            $em->flush();
+            $this->flushWithoutSoftDeleteListener($em);
 
             // Gedmo\Loggable writes its own "removed" log entry as part of the flush above, so the
             // audit-log purge must happen after — purging first would just leave that final row behind.
@@ -58,10 +62,10 @@ class SeasonRepository extends ServiceEntityRepository
 
     /**
      * Purges Gedmo\SoftDeleteable rows and schedules $season for removal, without flushing — lets
-     * a caller batch several seasons' removal into one flush (see UserRepository::deleteUser(),
-     * which combines this with removing the user in a single flush; calling flush() separately
-     * per season there confuses Doctrine's change-set detection for still-managed entities tied
-     * to the bulk-deleted rows above).
+     * a caller batch several seasons' removal into one flush (see UserRepository::deleteUser()).
+     * $season itself is also Gedmo\SoftDeleteable, so the caller must flush via
+     * flushWithoutSoftDeleteListener() below, or this permanent deletion becomes just another
+     * soft-delete (setting deletedAt) instead.
      *
      * @return list<string> the season's BankQuestion ids, to purge their audit log once flushed
      */
@@ -72,6 +76,37 @@ class SeasonRepository extends ServiceEntityRepository
         $em->remove($season);
 
         return $bankQuestionIds;
+    }
+
+    /**
+     * Flushes with Gedmo\SoftDeleteableListener temporarily detached, so a Season scheduled for
+     * removal (via scheduleForRemoval() above) is actually deleted instead of merely getting its
+     * deletedAt set. This also sidesteps a second Gedmo quirk: its listener calls persist() on
+     * each soft-deleted entity to record the timestamp, and persist() cascades into any
+     * cascade:['persist'] association — Season's Quiz/Candidate/BankQuestion/QuestionLabel — which
+     * silently *cancels* their own cascaded deletion within the same flush. Detaching the listener
+     * for this one flush restores the plain cascade-delete behavior all of this already relied on
+     * before Season became SoftDeleteable.
+     */
+    public function flushWithoutSoftDeleteListener(EntityManagerInterface $em): void
+    {
+        $eventManager = $em->getEventManager();
+        $listeners = array_filter(
+            $eventManager->getListeners('onFlush'),
+            static fn (object $listener): bool => $listener instanceof SoftDeleteableListener,
+        );
+
+        foreach ($listeners as $listener) {
+            $eventManager->removeEventListener('onFlush', $listener);
+        }
+
+        try {
+            $em->flush();
+        } finally {
+            foreach ($listeners as $listener) {
+                $eventManager->addEventListener('onFlush', $listener);
+            }
+        }
     }
 
     /**

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -9,6 +9,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Tvdt\Entity\User;
+use Tvdt\Helpers\SoftDeleteableFilter;
 
 /** @extends ServiceEntityRepository<User> */
 class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
@@ -49,14 +50,13 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             // Seasons the user already soft-deleted must still be purged for good here — account
             // deletion is a GDPR erasure request, not just a cleanup of what's currently visible —
             // so the softdeleteable filter that normally hides those seasons is disabled while
-            // reading this collection.
-            $filters = $em->getFilters();
-            $filters->disable('softdeleteable');
-            try {
-                $seasons = $user->seasons->toArray();
-            } finally {
-                $filters->enable('softdeleteable');
-            }
+            // fetching them. A fresh repository query is used rather than $user->seasons->toArray()
+            // so this can't be defeated by that collection having already been lazily loaded
+            // (under the filter's default enabled state) earlier in the same request.
+            $seasons = SoftDeleteableFilter::withDisabled(
+                $em,
+                fn (): array => $this->seasonRepository->getSeasonsForUser($user),
+            );
 
             $bankQuestionIds = [];
             foreach ($seasons as $season) {
@@ -70,9 +70,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             }
 
             $em->remove($user);
-            $this->seasonRepository->flushWithoutSoftDeleteListener($em);
-
-            $this->seasonRepository->purgeBankQuestionAuditLog($em, $bankQuestionIds);
+            $this->seasonRepository->flushAndPurgeBankQuestionAuditLog($em, $bankQuestionIds);
         });
     }
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -46,8 +46,20 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $em->wrapInTransaction(function () use ($em, $user): void {
             $this->invalidateResetPasswordRequests($user);
 
+            // Seasons the user already soft-deleted must still be purged for good here — account
+            // deletion is a GDPR erasure request, not just a cleanup of what's currently visible —
+            // so the softdeleteable filter that normally hides those seasons is disabled while
+            // reading this collection.
+            $filters = $em->getFilters();
+            $filters->disable('softdeleteable');
+            try {
+                $seasons = $user->seasons->toArray();
+            } finally {
+                $filters->enable('softdeleteable');
+            }
+
             $bankQuestionIds = [];
-            foreach ($user->seasons->toArray() as $season) {
+            foreach ($seasons as $season) {
                 if (1 === $season->owners->count()) {
                     array_push($bankQuestionIds, ...$this->seasonRepository->scheduleForRemoval($em, $season));
 
@@ -58,7 +70,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             }
 
             $em->remove($user);
-            $em->flush();
+            $this->seasonRepository->flushWithoutSoftDeleteListener($em);
 
             $this->seasonRepository->purgeBankQuestionAuditLog($em, $bankQuestionIds);
         });

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -5,22 +5,18 @@ declare(strict_types=1);
 namespace Tvdt\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
-use Tvdt\Entity\BankQuestion;
-use Tvdt\Entity\Elimination;
-use Tvdt\Entity\GivenAnswer;
-use Tvdt\Entity\QuizCandidate;
-use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
 
 /** @extends ServiceEntityRepository<User> */
 class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
 {
-    public function __construct(ManagerRegistry $registry)
-    {
+    public function __construct(
+        ManagerRegistry $registry,
+        private readonly SeasonRepository $seasonRepository,
+    ) {
         parent::__construct($registry, User::class);
     }
 
@@ -53,9 +49,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             $bankQuestionIds = [];
             foreach ($user->seasons->toArray() as $season) {
                 if (1 === $season->owners->count()) {
-                    $this->purgeSoftDeletableData($em, $season);
-                    array_push($bankQuestionIds, ...$this->bankQuestionIds($season));
-                    $em->remove($season);
+                    array_push($bankQuestionIds, ...$this->seasonRepository->scheduleForRemoval($em, $season));
 
                     continue;
                 }
@@ -66,60 +60,8 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             $em->remove($user);
             $em->flush();
 
-            // Gedmo\Loggable writes its own "removed" log entry as part of the flush above, so the
-            // audit-log purge must happen after — purging first would just leave that final row behind.
-            $this->purgeBankQuestionAuditLog($em, $bankQuestionIds);
+            $this->seasonRepository->purgeBankQuestionAuditLog($em, $bankQuestionIds);
         });
-    }
-
-    /**
-     * QuizCandidate, GivenAnswer, and Elimination are Gedmo\SoftDeleteable, so cascading their
-     * removal through the season/quiz/candidate relations only sets deletedAt — it never removes
-     * the row. That leaves personal data behind indefinitely and, since Candidate/Answer are hard
-     * deleted via orphanRemoval, it also breaks their foreign keys and rolls back the whole
-     * deletion. Bulk DQL deletes bypass the Gedmo listener and physically remove these rows first.
-     */
-    private function purgeSoftDeletableData(EntityManagerInterface $em, Season $season): void
-    {
-        foreach ([QuizCandidate::class, GivenAnswer::class, Elimination::class] as $class) {
-            $em->createQuery(<<<DQL
-                delete from {$class} e
-                where e.quiz in (select q from Tvdt\Entity\Quiz q where q.season = :season)
-                DQL)
-                ->setParameter('season', $season)
-                ->execute();
-        }
-    }
-
-    /** @return list<string> */
-    private function bankQuestionIds(Season $season): array
-    {
-        return array_values(array_map(
-            static fn (BankQuestion $bankQuestion): string => $bankQuestion->id->toString(),
-            $season->bankQuestions->toArray(),
-        ));
-    }
-
-    /**
-     * Gedmo\Loggable audit rows (ext_log_entries) aren't foreign-keyed to the entity they log —
-     * object_id is a plain string — so removing a BankQuestion never cleans up its history, and
-     * the editor's username/email would otherwise remain in those rows forever.
-     *
-     * @param list<string> $bankQuestionIds
-     */
-    private function purgeBankQuestionAuditLog(EntityManagerInterface $em, array $bankQuestionIds): void
-    {
-        if ([] === $bankQuestionIds) {
-            return;
-        }
-
-        $em->createQuery(<<<'DQL'
-            delete from Tvdt\Entity\LogEntry l
-            where l.objectClass = :class and l.objectId in (:ids)
-            DQL)
-            ->setParameter('class', BankQuestion::class)
-            ->setParameter('ids', $bankQuestionIds)
-            ->execute();
     }
 
     public function makeAdmin(string $email): void

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -22,6 +22,7 @@ use Tvdt\Entity\User;
 use Tvdt\Enum\ScreenColour;
 use Tvdt\Helpers\FilenameSanitizer;
 use Tvdt\Helpers\FormulaInjectionSafeValueBinder;
+use Tvdt\Helpers\SoftDeleteableFilter;
 use Tvdt\Repository\QuizRepository;
 
 use function Safe\tempnam;
@@ -41,14 +42,7 @@ class DataExportService
     /** @throws FilesystemException @return string path to a temp zip file; caller is responsible for removing it */
     public function exportForUser(User $user): string
     {
-        $filter = $this->entityManager->getFilters();
-        $filter->disable('softdeleteable');
-
-        try {
-            return $this->buildZip($user);
-        } finally {
-            $filter->enable('softdeleteable');
-        }
+        return SoftDeleteableFilter::withDisabled($this->entityManager, fn (): string => $this->buildZip($user));
     }
 
     private function buildZip(User $user): string

--- a/src/Service/DataExportService.php
+++ b/src/Service/DataExportService.php
@@ -120,7 +120,7 @@ class DataExportService
 
         $seasons = $spreadsheet->createSheet();
         $seasons->setTitle('Seasons');
-        $seasons->fromArray(['Season', 'Season code', 'Quizzes', 'Candidates', 'Shared with other owners'], null, 'A1');
+        $seasons->fromArray(['Season', 'Season code', 'Quizzes', 'Candidates', 'Shared with other owners', 'Deleted'], null, 'A1');
         $seasons->getStyle('1:1')->getFont()->setBold(true);
 
         $row = 2;
@@ -131,11 +131,12 @@ class DataExportService
                 $season->quizzes->count(),
                 $season->candidates->count(),
                 $season->owners->count() > 1 ? 'Yes' : 'No',
+                $season->getDeletedAt()?->format(\DateTimeInterface::ATOM) ?? '',
             ], null, 'A'.$row);
             ++$row;
         }
 
-        foreach (['A', 'B', 'C', 'D', 'E'] as $column) {
+        foreach (['A', 'B', 'C', 'D', 'E', 'F'] as $column) {
             $seasons->getColumnDimension($column)->setAutoSize(true);
         }
 
@@ -377,6 +378,7 @@ class DataExportService
             ['Show numbers', $season->settings?->showNumbers ? 'Yes' : 'No'],
             ['Confirm answers', $season->settings?->confirmAnswers ? 'Yes' : 'No'],
             ['Shared with other owners', $season->owners->count() > 1 ? 'Yes' : 'No'],
+            ['Deleted', $season->getDeletedAt()?->format(\DateTimeInterface::ATOM) ?? ''],
         ], null, 'A1');
         $infoSheet->getColumnDimension('A')->setAutoSize(true);
         $infoSheet->getColumnDimension('B')->setAutoSize(true);

--- a/src/Service/GitHubReleasesService.php
+++ b/src/Service/GitHubReleasesService.php
@@ -14,7 +14,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final readonly class GitHubReleasesService
 {
-    private const string RELEASES_URL = 'https://api.github.com/repos/MarijnDoeve/TijdVoorDeTest/releases';
+    private const string RELEASES_URL = 'https://api.github.com/repos/TijdVoorDeTest/TijdVoorDeTest/releases';
 
     public function __construct(
         private HttpClientInterface $httpClient,

--- a/templates/backoffice/season/tab_settings.html.twig
+++ b/templates/backoffice/season/tab_settings.html.twig
@@ -43,7 +43,7 @@
             </button>
         </form>
 
-        <p>{{ 'Deleting this season permanently removes it, its tests, and all candidate answers. This cannot be undone.'|trans }}</p>
+        <p>{{ 'Deleting this season hides it, its tests, and all candidate answers everywhere. There is no way to undo this yourself yet.'|trans }}</p>
         <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteSeasonModal">
             {{ 'Delete season...'|trans }}
         </button>
@@ -105,7 +105,7 @@
 
 <div class="modal fade" id="deleteSeasonModal" data-bs-backdrop="static"
      data-controller="bo--modal bo--type-to-confirm" data-bo--modal-target="modal"
-     data-bo--type-to-confirm-word-value="verwijderen"
+     data-bo--type-to-confirm-words-value="{{ ['verwijderen', 'delete']|json_encode }}"
      data-action="hidden.bs.modal->bo--modal#resetDirty"
      tabindex="-1" aria-labelledby="deleteSeasonModalLabel" aria-hidden="true">
     <div class="modal-dialog">
@@ -116,10 +116,10 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body text-start">
-                    <p>{{ 'This permanently deletes this season, its tests, and all candidate answers. This cannot be undone.'|trans }}</p>
+                    <p>{{ 'This hides this season, its tests, and all candidate answers everywhere. There is no way to undo this yourself yet.'|trans }}</p>
                     <input type="hidden" name="_token" value="{{ csrf_token('delete_season') }}">
                     <label class="form-label" for="deleteSeasonConfirmation">
-                        {{ 'Type {word} to confirm'|trans({word: 'verwijderen'}) }}
+                        {{ 'Type delete to confirm'|trans }}
                     </label>
                     <input type="text" class="form-control" id="deleteSeasonConfirmation" name="confirmation"
                            autocomplete="off" autofocus

--- a/templates/backoffice/season/tab_settings.html.twig
+++ b/templates/backoffice/season/tab_settings.html.twig
@@ -4,17 +4,81 @@
 
         <hr>
 
-        <h4 class="text-danger">{{ 'Season code'|trans }}</h4>
+        <h4>{{ 'Owners'|trans }}</h4>
+        <ul class="list-group mb-3">
+            {% for owner in season.owners %}
+                <li class="list-group-item d-flex align-items-center justify-content-between gap-2">
+                    {{ owner.email }}
+                    {% if season.owners|length > 1 %}
+                        <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal"
+                                data-bs-target="#removeOwner-{{ owner.id }}">{{ 'Remove'|trans }}</button>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+
+        <form action="{{ path('tvdt_backoffice_season_add_owner', {seasonCode: season.seasonCode}) }}" method="POST" class="mb-3">
+            <input type="hidden" name="_token" value="{{ csrf_token('add_season_owner') }}">
+            <div class="input-group">
+                <input type="email" name="email" class="form-control" placeholder="{{ 'Email address'|trans }}" required>
+                <button type="submit" class="btn btn-outline-primary">{{ 'Add owner'|trans }}</button>
+            </div>
+        </form>
+
+        <hr>
+
+        <h4 class="text-danger">{{ 'Danger zone'|trans }}</h4>
+
+        <p><strong>{{ 'Season code'|trans }}:</strong> {{ season.seasonCode }}</p>
         <p>{{ 'The season code is used by candidates to join this season. Regenerating it invalidates the current code, so make sure to share the new one.'|trans }}</p>
-        <p><strong>{{ 'Current code:'|trans }}</strong> {{ season.seasonCode }}</p>
-        <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#regenerateSeasonCodeModal">
+        <button type="button" class="btn btn-danger mb-3" data-bs-toggle="modal" data-bs-target="#regenerateSeasonCodeModal">
             {{ 'Regenerate season code...'|trans }}
+        </button>
+
+        <p>{{ 'Leaving this season removes your ownership. You need at least one other owner before you can leave.'|trans }}</p>
+        <form action="{{ path('tvdt_backoffice_season_remove_owner', {seasonCode: season.seasonCode, owner: app.user.id}) }}" method="POST" class="mb-3">
+            <input type="hidden" name="_token" value="{{ csrf_token('remove_season_owner') }}">
+            <button type="submit" class="btn btn-danger" {{ season.owners|length <= 1 ? 'disabled' : '' }}>
+                {{ 'Leave season'|trans }}
+            </button>
+        </form>
+
+        <p>{{ 'Deleting this season permanently removes it, its tests, and all candidate answers. This cannot be undone.'|trans }}</p>
+        <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteSeasonModal">
+            {{ 'Delete season...'|trans }}
         </button>
     </div>
     <div class="col-md-6 col-12">
         {{ include('backoffice/help/season_settings.html.twig') }}
     </div>
 </div>
+
+{% for owner in season.owners %}
+    {% if season.owners|length > 1 %}
+        <div class="modal fade" id="removeOwner-{{ owner.id }}" data-bs-backdrop="static"
+             tabindex="-1" aria-labelledby="removeOwner-{{ owner.id }}Label" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-5" id="removeOwner-{{ owner.id }}Label">{{ 'Please Confirm'|trans }}</h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body text-start">
+                        {{ 'Are you sure you want to remove {email} as an owner of this season?'|trans({email: owner.email}) }}
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'No'|trans }}</button>
+                        <form action="{{ path('tvdt_backoffice_season_remove_owner', {seasonCode: season.seasonCode, owner: owner.id}) }}"
+                              method="POST">
+                            <input type="hidden" name="_token" value="{{ csrf_token('remove_season_owner') }}">
+                            <button type="submit" class="btn btn-danger">{{ 'Yes'|trans }}</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endfor %}
 
 <div class="modal fade" id="regenerateSeasonCodeModal" data-bs-backdrop="static"
      tabindex="-1"
@@ -33,6 +97,40 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
                     <button type="submit" class="btn btn-danger">{{ 'Regenerate season code'|trans }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="deleteSeasonModal" data-bs-backdrop="static"
+     data-controller="bo--modal bo--type-to-confirm" data-bo--modal-target="modal"
+     data-bo--type-to-confirm-word-value="verwijderen"
+     data-action="hidden.bs.modal->bo--modal#resetDirty"
+     tabindex="-1" aria-labelledby="deleteSeasonModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form action="{{ path('tvdt_backoffice_season_delete', {seasonCode: season.seasonCode}) }}" method="POST">
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="deleteSeasonModalLabel">{{ 'Delete season'|trans }}</h1>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body text-start">
+                    <p>{{ 'This permanently deletes this season, its tests, and all candidate answers. This cannot be undone.'|trans }}</p>
+                    <input type="hidden" name="_token" value="{{ csrf_token('delete_season') }}">
+                    <label class="form-label" for="deleteSeasonConfirmation">
+                        {{ 'Type {word} to confirm'|trans({word: 'verwijderen'}) }}
+                    </label>
+                    <input type="text" class="form-control" id="deleteSeasonConfirmation" name="confirmation"
+                           autocomplete="off" autofocus
+                           data-bo--type-to-confirm-target="input"
+                           data-action="input->bo--modal#markDirty change->bo--modal#markDirty input->bo--type-to-confirm#check">
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
+                    <button type="submit" class="btn btn-danger" disabled data-bo--type-to-confirm-target="submit">
+                        {{ 'Delete season'|trans }}
+                    </button>
                 </div>
             </form>
         </div>

--- a/templates/backoffice/season/tab_settings.html.twig
+++ b/templates/backoffice/season/tab_settings.html.twig
@@ -1,3 +1,4 @@
+{% set canRemoveOwner = season.owners|length > 1 %}
 <div class="row">
     <div class="col-md-6 col-12">
         {{ form(form) }}
@@ -9,7 +10,7 @@
             {% for owner in season.owners %}
                 <li class="list-group-item d-flex align-items-center justify-content-between gap-2">
                     {{ owner.email }}
-                    {% if season.owners|length > 1 %}
+                    {% if canRemoveOwner %}
                         <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal"
                                 data-bs-target="#removeOwner-{{ owner.id }}">{{ 'Remove'|trans }}</button>
                     {% endif %}
@@ -38,7 +39,7 @@
         <p>{{ 'Leaving this season removes your ownership. You need at least one other owner before you can leave.'|trans }}</p>
         <form action="{{ path('tvdt_backoffice_season_remove_owner', {seasonCode: season.seasonCode, owner: app.user.id}) }}" method="POST" class="mb-3">
             <input type="hidden" name="_token" value="{{ csrf_token('remove_season_owner') }}">
-            <button type="submit" class="btn btn-danger" {{ season.owners|length <= 1 ? 'disabled' : '' }}>
+            <button type="submit" class="btn btn-danger" {{ canRemoveOwner ? '' : 'disabled' }}>
                 {{ 'Leave season'|trans }}
             </button>
         </form>
@@ -54,7 +55,7 @@
 </div>
 
 {% for owner in season.owners %}
-    {% if season.owners|length > 1 %}
+    {% if canRemoveOwner %}
         <div class="modal fade" id="removeOwner-{{ owner.id }}" data-bs-backdrop="static"
              tabindex="-1" aria-labelledby="removeOwner-{{ owner.id }}Label" aria-hidden="true">
             <div class="modal-dialog">

--- a/tests/Integration/Controller/Backoffice/QuizControllerTest.php
+++ b/tests/Integration/Controller/Backoffice/QuizControllerTest.php
@@ -78,6 +78,51 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
         $this->assertStringContainsString('/candidates/', (string) $this->client->getResponse()->headers->get('Location'));
     }
 
+    public function testIndexRejectsQuizFromAnotherSeason(): void
+    {
+        $foreignQuiz = $this->getQuizByName('Doomed Quiz', 'doomd');
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s', $foreignQuiz->id));
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testOverviewRejectsQuizFromAnotherSeason(): void
+    {
+        $foreignQuiz = $this->getQuizByName('Doomed Quiz', 'doomd');
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s/overview', $foreignQuiz->id));
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testResultRejectsQuizFromAnotherSeason(): void
+    {
+        $foreignQuiz = $this->getQuizByName('Doomed Quiz', 'doomd');
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s/result', $foreignQuiz->id));
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testCandidatesTabRejectsQuizFromAnotherSeason(): void
+    {
+        $foreignQuiz = $this->getQuizByName('Doomed Quiz', 'doomd');
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s/candidates-list', $foreignQuiz->id));
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testAnswerMappingRejectsQuizFromAnotherSeason(): void
+    {
+        $foreignQuiz = $this->getQuizByName('Doomed Quiz', 'doomd');
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/backoffice/season/krtek/quiz/%s/answer-mapping', $foreignQuiz->id));
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
     public function testCandidatesQuestionTabLoadsSuccessfully(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');
@@ -134,6 +179,27 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
         ));
     }
 
+    public function testEnableQuizRejectsQuizFromAnotherSeason(): void
+    {
+        $originalActiveQuizId = $this->getSeasonByCode('krtek')->activeQuiz?->id;
+        $foreignQuiz = $this->getQuizByName('Doomed Quiz', 'doomd');
+
+        $token = $this->getCsrfTokenFromPage(
+            \sprintf('/backoffice/season/krtek/quiz/%s/overview', $this->getQuizByName('Quiz 1')->id),
+            '/enable',
+        );
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/quiz/%s/enable', $foreignQuiz->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+        $this->entityManager->clear();
+
+        $updated = $this->getSeasonByCode('krtek');
+        $this->assertSame($originalActiveQuizId?->toString(), $updated->activeQuiz?->id?->toString());
+    }
+
     public function testToggleCandidateCreatesInactiveQuizCandidate(): void
     {
         $quiz = $this->getQuizByName('Quiz 1');
@@ -185,6 +251,87 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
         ]);
         $this->assertInstanceOf(QuizCandidate::class, $updated);
         $this->assertTrue($updated->active);
+    }
+
+    public function testToggleCandidateRejectsCandidateFromAnotherSeason(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $foreignCandidate = $this->getCandidate('Vera', 'doomd');
+
+        $token = $this->getCsrfTokenFromPage(\sprintf('/backoffice/season/krtek/quiz/%s/candidates-list', $quiz->id), '/toggle');
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/candidate/%s/toggle', $quiz->id, $foreignCandidate->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+        $this->entityManager->clear();
+
+        $quizCandidate = $this->entityManager->getRepository(QuizCandidate::class)->findOneBy([
+            'quiz' => $quiz,
+            'candidate' => $foreignCandidate,
+        ]);
+        $this->assertNotInstanceOf(QuizCandidate::class, $quizCandidate);
+    }
+
+    public function testResetCandidateProgressRejectsCandidateFromAnotherSeason(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $candidate = $this->getCandidate('Tom');
+        $foreignCandidate = $this->getCandidate('Vera', 'doomd');
+
+        // A reset-progress form only renders for a candidate that has started, so give Tom
+        // that state purely to make the (candidate-agnostic) CSRF token appear on the page.
+        $quizCandidate = new QuizCandidate($quiz, $candidate);
+        $quizCandidate->started = new DateTimeImmutable();
+
+        $this->entityManager->persist($quizCandidate);
+        $this->entityManager->flush();
+
+        $token = $this->getCsrfTokenFromPage(\sprintf('/backoffice/season/krtek/quiz/%s/candidates-list', $quiz->id), '/reset');
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/candidate/%s/reset', $quiz->id, $foreignCandidate->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testModifyResultRejectsCandidateFromAnotherSeason(): void
+    {
+        $quiz = $this->getQuizByName('Quiz 1');
+        $candidate = $this->getCandidate('Tom');
+        $foreignCandidate = $this->getCandidate('Vera', 'doomd');
+
+        // getScores() requires started IS NOT NULL and at least one GivenAnswer, purely to make
+        // the (candidate-agnostic) modify_result CSRF token appear on the result page.
+        $quizCandidate = new QuizCandidate($quiz, $candidate);
+        $quizCandidate->started = new DateTimeImmutable();
+
+        $this->entityManager->persist($quizCandidate);
+        $firstQuestion = $quiz->questions->first();
+        $this->assertInstanceOf(Question::class, $firstQuestion);
+        $answer = $firstQuestion->answers->first();
+        $this->assertInstanceOf(Answer::class, $answer);
+        $this->entityManager->persist(new GivenAnswer($candidate, $quiz, $answer));
+        $this->entityManager->flush();
+
+        $token = $this->getCsrfTokenFromPage(\sprintf('/backoffice/season/krtek/quiz/%s/result', $quiz->id), '/modify_result');
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/quiz/%s/candidate/%s/modify_result', $quiz->id, $foreignCandidate->id), [
+            '_token' => $token,
+            'corrections' => '1.5',
+            'penalty' => '30',
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+        $this->entityManager->clear();
+
+        $updated = $this->entityManager->getRepository(QuizCandidate::class)->findOneBy([
+            'quiz' => $quiz,
+            'candidate' => $foreignCandidate,
+        ]);
+        $this->assertNotInstanceOf(QuizCandidate::class, $updated);
     }
 
     public function testResetCandidateProgressDeletesGivenAnswersAndClearsStarted(): void

--- a/tests/Integration/Controller/Backoffice/SeasonControllerTest.php
+++ b/tests/Integration/Controller/Backoffice/SeasonControllerTest.php
@@ -189,4 +189,149 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
 
         self::assertResponseStatusCodeSame(403);
     }
+
+    public function testAddOwnerByEmailGrantsOwnership(): void
+    {
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', '/add-owner');
+
+        $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/add-owner', [
+            '_token' => $token,
+            'email' => 'test@example.org',
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/settings');
+        $this->entityManager->clear();
+
+        $newOwner = $this->getUserByEmail('test@example.org');
+        $season = $this->getSeasonByCode('krtek');
+        $this->assertTrue($season->isOwner($newOwner));
+    }
+
+    public function testAddOwnerWithUnknownEmailShowsWarningAndDoesNotChangeOwners(): void
+    {
+        $ownerCountBefore = $this->getSeasonByCode('krtek')->owners->count();
+
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', '/add-owner');
+
+        $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/add-owner', [
+            '_token' => $token,
+            'email' => 'nobody@example.org',
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/settings');
+        $this->entityManager->clear();
+
+        $this->assertCount($ownerCountBefore, $this->getSeasonByCode('krtek')->owners);
+    }
+
+    public function testAddOwnerIsDeniedForNonOwner(): void
+    {
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', '/add-owner');
+
+        $this->loginAs('test@example.org');
+
+        $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/add-owner', [
+            '_token' => $token,
+            'email' => 'test@example.org',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testRemoveOwnerRemovesOwnership(): void
+    {
+        $user2 = $this->getUserByEmail('user2@example.org');
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', \sprintf('/owner/%s/remove', $user2->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/settings/owner/%s/remove', $user2->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/settings');
+        $this->entityManager->clear();
+
+        $user2 = $this->getUserByEmail('user2@example.org');
+        $this->assertFalse($this->getSeasonByCode('krtek')->isOwner($user2));
+    }
+
+    public function testRemoveOwnerIsBlockedWhenItWouldLeaveNoOwners(): void
+    {
+        $this->loginAs('sole-owner@example.org');
+        $soleOwner = $this->getUserByEmail('sole-owner@example.org');
+
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/doomd/settings', \sprintf('/owner/%s/remove', $soleOwner->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/doomd/settings/owner/%s/remove', $soleOwner->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/doomd/settings');
+        $this->entityManager->clear();
+
+        $soleOwner = $this->getUserByEmail('sole-owner@example.org');
+        $this->assertTrue($this->getSeasonByCode('doomd')->isOwner($soleOwner));
+    }
+
+    public function testLeaveSeasonRemovesOwnershipAndRedirectsToIndex(): void
+    {
+        $krtekAdmin = $this->getUserByEmail('krtek-admin@example.org');
+
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', \sprintf('/owner/%s/remove', $krtekAdmin->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/settings/owner/%s/remove', $krtekAdmin->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/backoffice/');
+        $this->entityManager->clear();
+
+        $krtekAdmin = $this->getUserByEmail('krtek-admin@example.org');
+        $this->assertFalse($this->getSeasonByCode('krtek')->isOwner($krtekAdmin));
+    }
+
+    public function testDeleteSeasonWithCorrectConfirmationDeletesSeason(): void
+    {
+        $seasonId = $this->getSeasonByCode('krtek')->id;
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', '/settings/delete');
+
+        $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/delete', [
+            '_token' => $token,
+            'confirmation' => 'verwijderen',
+        ]);
+
+        self::assertResponseRedirects('/backoffice/');
+        $this->entityManager->clear();
+
+        $this->assertNotInstanceOf(Season::class, $this->entityManager->getRepository(Season::class)->find($seasonId));
+    }
+
+    public function testDeleteSeasonWithWrongConfirmationKeepsSeason(): void
+    {
+        $seasonId = $this->getSeasonByCode('krtek')->id;
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', '/settings/delete');
+
+        $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/delete', [
+            '_token' => $token,
+            'confirmation' => 'wrong',
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/settings');
+        $this->entityManager->clear();
+
+        $this->assertInstanceOf(Season::class, $this->entityManager->getRepository(Season::class)->find($seasonId));
+    }
+
+    public function testDeleteSeasonIsDeniedForNonOwner(): void
+    {
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', '/settings/delete');
+
+        $this->loginAs('test@example.org');
+
+        $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/delete', [
+            '_token' => $token,
+            'confirmation' => 'verwijderen',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
 }

--- a/tests/Integration/Controller/Backoffice/SeasonControllerTest.php
+++ b/tests/Integration/Controller/Backoffice/SeasonControllerTest.php
@@ -289,7 +289,7 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
         $this->assertFalse($this->getSeasonByCode('krtek')->isOwner($krtekAdmin));
     }
 
-    public function testDeleteSeasonWithCorrectConfirmationDeletesSeason(): void
+    public function testDeleteSeasonWithCorrectConfirmationSoftDeletesSeason(): void
     {
         $seasonId = $this->getSeasonByCode('krtek')->id;
         $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', '/settings/delete');
@@ -297,6 +297,30 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
         $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/delete', [
             '_token' => $token,
             'confirmation' => 'verwijderen',
+        ]);
+
+        self::assertResponseRedirects('/backoffice/');
+        $this->entityManager->clear();
+
+        // Filtered lookups must no longer see it...
+        $this->assertNotInstanceOf(Season::class, $this->entityManager->getRepository(Season::class)->find($seasonId));
+
+        // ...but the row itself must still exist with deletedAt set — a soft delete, not a hard one.
+        $connection = $this->entityManager->getConnection();
+        $this->assertSame(
+            1,
+            (int) $connection->fetchOne('select count(*) from season where id = ? and deleted_at is not null', [$seasonId->toString()]),
+        );
+    }
+
+    public function testDeleteSeasonAcceptsTheEnglishConfirmationWord(): void
+    {
+        $seasonId = $this->getSeasonByCode('krtek')->id;
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', '/settings/delete');
+
+        $this->client->request(Request::METHOD_POST, '/backoffice/season/krtek/settings/delete', [
+            '_token' => $token,
+            'confirmation' => 'delete',
         ]);
 
         self::assertResponseRedirects('/backoffice/');

--- a/tests/Integration/Controller/Backoffice/SeasonControllerTest.php
+++ b/tests/Integration/Controller/Backoffice/SeasonControllerTest.php
@@ -254,6 +254,27 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
         $this->assertFalse($this->getSeasonByCode('krtek')->isOwner($user2));
     }
 
+    public function testRemoveOwnerOfNonMemberDoesNothing(): void
+    {
+        $nonMember = $this->getUserByEmail('test@example.org');
+        $this->assertFalse($this->getSeasonByCode('krtek')->isOwner($nonMember));
+        $ownerCountBefore = $this->getSeasonByCode('krtek')->owners->count();
+
+        // The CSRF token for 'remove_season_owner' isn't tied to a specific owner id, so it's
+        // safe to fetch it from an existing owner's remove form and reuse it against $nonMember.
+        $user2 = $this->getUserByEmail('user2@example.org');
+        $token = $this->getCsrfTokenFromPage('/backoffice/season/krtek/settings', \sprintf('/owner/%s/remove', $user2->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/backoffice/season/krtek/settings/owner/%s/remove', $nonMember->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/backoffice/season/krtek/settings');
+        $this->entityManager->clear();
+
+        $this->assertCount($ownerCountBefore, $this->getSeasonByCode('krtek')->owners);
+    }
+
     public function testRemoveOwnerIsBlockedWhenItWouldLeaveNoOwners(): void
     {
         $this->loginAs('sole-owner@example.org');

--- a/tests/Integration/Repository/SeasonRepositoryTest.php
+++ b/tests/Integration/Repository/SeasonRepositoryTest.php
@@ -71,6 +71,7 @@ final class SeasonRepositoryTest extends DatabaseTestCase
     {
         $season = $this->getSeasonByCode('bbbbb');
         $this->assertGreaterThan(1, $season->owners->count());
+        $seasonId = $season->id->toString();
 
         $bankQuestion = new BankQuestion();
         $bankQuestion->question = 'Wie is de Krtek eigenlijk?';
@@ -91,7 +92,9 @@ final class SeasonRepositoryTest extends DatabaseTestCase
         $this->seasonRepository->deleteSeason($season);
         $this->entityManager->clear();
 
-        $this->assertNotInstanceOf(Season::class, $this->seasonRepository->findOneBySeasonCode('bbbbb'));
+        // Season is Gedmo\SoftDeleteable, so findOneBySeasonCode() (filtered) would return null
+        // even for a merely soft-deleted row — only a raw row count proves it's truly gone.
+        $this->assertSame(0, (int) $connection->fetchOne('select count(*) from season where id = ?', [$seasonId]));
 
         $logCountAfter = (int) $connection->fetchOne(
             'select count(*) from ext_log_entries where object_class = ? and object_id = ?',

--- a/tests/Integration/Repository/SeasonRepositoryTest.php
+++ b/tests/Integration/Repository/SeasonRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Tvdt\Tests\Integration\Repository;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Tvdt\Entity\BankQuestion;
 use Tvdt\Entity\Season;
 use Tvdt\Repository\SeasonRepository;
 
@@ -58,5 +59,44 @@ final class SeasonRepositoryTest extends DatabaseTestCase
     {
         $season = $this->seasonRepository->findOneBySeasonCode('invalid');
         $this->assertNotInstanceOf(Season::class, $season);
+    }
+
+    /**
+     * deleteSeason() must purge Gedmo\Loggable audit rows even when the season being deleted
+     * isn't the caller's sole season (that path is also exercised indirectly via
+     * UserRepository::deleteUser() for a sole-owner account, but a direct "delete this season"
+     * action needs the same cleanup on a season with multiple owners).
+     */
+    public function testDeleteSeasonPurgesBankQuestionAuditLogOnAMultiOwnerSeason(): void
+    {
+        $season = $this->getSeasonByCode('bbbbb');
+        $this->assertGreaterThan(1, $season->owners->count());
+
+        $bankQuestion = new BankQuestion();
+        $bankQuestion->question = 'Wie is de Krtek eigenlijk?';
+        $bankQuestion->season = $season;
+
+        $this->entityManager->persist($bankQuestion);
+        $this->entityManager->flush();
+
+        $bankQuestionId = $bankQuestion->id->toString();
+        $connection = $this->entityManager->getConnection();
+
+        $logCountBefore = (int) $connection->fetchOne(
+            'select count(*) from ext_log_entries where object_class = ? and object_id = ?',
+            [BankQuestion::class, $bankQuestionId],
+        );
+        $this->assertGreaterThan(0, $logCountBefore);
+
+        $this->seasonRepository->deleteSeason($season);
+        $this->entityManager->clear();
+
+        $this->assertNotInstanceOf(Season::class, $this->seasonRepository->findOneBySeasonCode('bbbbb'));
+
+        $logCountAfter = (int) $connection->fetchOne(
+            'select count(*) from ext_log_entries where object_class = ? and object_id = ?',
+            [BankQuestion::class, $bankQuestionId],
+        );
+        $this->assertSame(0, $logCountAfter);
     }
 }

--- a/tests/Integration/Repository/UserRepositoryTest.php
+++ b/tests/Integration/Repository/UserRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tvdt\Tests\Integration\Repository;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use Safe\DateTime;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Tvdt\DataFixtures\TestFixtures;
 use Tvdt\Entity\BankQuestion;
@@ -133,5 +134,29 @@ final class UserRepositoryTest extends DatabaseTestCase
             [BankQuestion::class, $bankQuestionId],
         );
         $this->assertSame(0, $logCountAfter);
+    }
+
+    /**
+     * Account deletion is a GDPR erasure request, not a visibility cleanup: a season the user
+     * already soft-deleted (e.g. via the season settings danger zone) must still be permanently
+     * purged when they're its sole owner, not left soft-deleted forever with no owner left to
+     * ever hard-delete it.
+     */
+    public function testDeleteUserPurgesAlreadySoftDeletedSoleOwnedSeason(): void
+    {
+        $user = $this->getUserByEmail('sole-owner@example.org');
+        $season = $this->getSeasonByCode('doomd');
+        $seasonId = $season->id->toString();
+
+        $season->setDeletedAt(new DateTime());
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $user = $this->getUserByEmail('sole-owner@example.org');
+        $this->userRepository->deleteUser($user);
+        $this->entityManager->clear();
+
+        $connection = $this->entityManager->getConnection();
+        $this->assertSame(0, (int) $connection->fetchOne('select count(*) from season where id = ?', [$seasonId]));
     }
 }

--- a/tests/Integration/Service/DataExportServiceTest.php
+++ b/tests/Integration/Service/DataExportServiceTest.php
@@ -9,6 +9,7 @@ use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\Attributes\CoversClass;
+use Safe\DateTime;
 use Tvdt\Entity\Answer;
 use Tvdt\Entity\Elimination;
 use Tvdt\Entity\EliminationScreenView;
@@ -166,6 +167,34 @@ final class DataExportServiceTest extends DatabaseTestCase
         $hasDeletedRow = array_any(\array_slice($rows, 1), static fn (array $row): bool => null !== $row[$deletedColumnIndex] && '' !== $row[$deletedColumnIndex]);
 
         $this->assertTrue($hasDeletedRow, 'Expected the soft-deleted QuizCandidate to still appear with a Deleted timestamp');
+    }
+
+    public function testSeasonsSheetAndSeasonInfoSheetIncludeSoftDeletedSeason(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $season->setDeletedAt(new DateTime());
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $zip = $this->openZip($this->getUserByEmail('krtek-admin@example.org'));
+        $profileContent = $zip->getFromName('profile.xlsx');
+        $this->assertIsString($profileContent);
+        $candidatesContent = $zip->getFromName('krtek-Krtek-Weekend/candidates.xlsx');
+        $this->assertIsString($candidatesContent);
+        $zip->close();
+
+        $seasonsRows = $this->loadSheet($profileContent, 'Seasons')->toArray();
+        $deletedColumnIndex = array_search('Deleted', $seasonsRows[0], true);
+        $this->assertIsInt($deletedColumnIndex);
+        $krtekRow = current(array_filter(\array_slice($seasonsRows, 1), static fn (array $row): bool => 'Krtek Weekend' === $row[0]));
+        $this->assertIsArray($krtekRow);
+        $this->assertNotEmpty($krtekRow[$deletedColumnIndex], 'Expected the soft-deleted season to still appear with a Deleted timestamp');
+
+        $infoRows = $this->loadSheet($candidatesContent, 'Season info')->toArray();
+        $deletedRow = current(array_filter($infoRows, static fn (array $row): bool => 'Deleted' === $row[0]));
+        $this->assertIsArray($deletedRow);
+        $this->assertNotEmpty($deletedRow[1], 'Expected the Season info sheet to show a Deleted timestamp');
     }
 
     public function testRawAnswersSheetShowsCandidatesByQuestionsGrid(): void

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -273,6 +273,7 @@ Submit: Verstuur
 'This quiz has already been filled in and can no longer be altered': 'Deze quiz is al ingevuld en kan niet meer worden gewijzigd'
 'This quiz has no questions yet': 'Deze test heeft nog geen vragen'
 'This user is already an owner of this season': 'Deze gebruiker is al eigenaar van dit seizoen'
+'This user is not an owner of this season': 'Deze gebruiker is geen eigenaar van dit seizoen'
 Time: Tijd
 'Toggle correct answer': 'Goed antwoord aan/uitzetten'
 'Type delete to confirm': 'Typ verwijderen om te bevestigen'

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -83,7 +83,7 @@ Delete: Verwijderen
 'Delete season': 'Seizoen verwijderen'
 'Delete season...': 'Seizoen verwijderen...'
 Delete...: Verwijderen...
-'Deleting this season permanently removes it, its tests, and all candidate answers. This cannot be undone.': 'Als je dit seizoen verwijdert, worden ook alle tests en antwoorden van kandidaten definitief verwijderd. Dit kan niet ongedaan worden gemaakt.'
+'Deleting this season hides it, its tests, and all candidate answers everywhere. There is no way to undo this yourself yet.': 'Als je dit seizoen verwijdert, wordt het overal verborgen, samen met de tests en antwoorden van kandidaten. Je kunt dit nog niet zelf ongedaan maken.'
 'Deleting your account also deletes every season you are the only owner of. This cannot be undone.': 'Als je je account verwijdert, worden ook alle seizoenen verwijderd waarvan jij de enige eigenaar bent. Dit kan niet ongedaan worden gemaakt.'
 Done: Klaar
 'Download Template': 'Download sjabloon'
@@ -262,9 +262,9 @@ Submit: Verstuur
 'There is already an account with this email': 'Er is al een account met dit e-mailadres'
 'There is no active quiz': 'Er is geen test actief'
 'This deletes your account and every season you are the only owner of. Enter your password to confirm.': 'Dit verwijdert je account en alle seizoenen waarvan jij de enige eigenaar bent. Vul je wachtwoord in om te bevestigen.'
+'This hides this season, its tests, and all candidate answers everywhere. There is no way to undo this yourself yet.': 'Dit verbergt dit seizoen overal, samen met de tests en antwoorden van kandidaten. Je kunt dit nog niet zelf ongedaan maken.'
 'This invalidates the current season code. Anyone using the old code will no longer be able to join this season.': 'Hiermee wordt de huidige seizoenscode ongeldig. Iedereen die de oude code gebruikt, kan dit seizoen niet meer vinden.'
 'This link will expire in {count}.': 'Deze link verloopt over {count}.'
-'This permanently deletes this season, its tests, and all candidate answers. This cannot be undone.': 'Dit verwijdert dit seizoen, de tests en alle antwoorden van kandidaten definitief. Dit kan niet ongedaan worden gemaakt.'
 'This question cannot be deleted because it is used in a locked or active quiz': 'Deze vraag kan niet verwijderd worden omdat die gebruik wordt in een vergrendelde of actieve test'
 'This question has already been used': 'Deze vraag is al gebruikt'
 'This question has been used in a quiz. The copy in the quiz will not be affected.': 'Deze vraag is gebruikt in een test. De kopie in de test blijft ongewijzigd.'
@@ -275,8 +275,7 @@ Submit: Verstuur
 'This user is already an owner of this season': 'Deze gebruiker is al eigenaar van dit seizoen'
 Time: Tijd
 'Toggle correct answer': 'Goed antwoord aan/uitzetten'
-"Type 'verwijderen' to confirm": "__Type 'verwijderen' to confirm"
-'Type {word} to confirm': 'Typ {word} om te bevestigen'
+'Type delete to confirm': 'Typ verwijderen om te bevestigen'
 Unassign: Ontkoppelen
 'Undo finalization': 'Afronden ongedaan maken'
 'Used in': 'Gebruikt in'

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -16,6 +16,7 @@ Add: Toevoegen
 'Add blank': 'Leeg toevoegen'
 'Add blank quiz': 'Lege quiz toevoegen'
 'Add label': 'Label toevoegen'
+'Add owner': 'Eigenaar toevoegen'
 'Add question': 'Vraag toevoegen'
 'After changing your email address you will receive a new confirmation email.': 'Na het wijzigen van je e-mailadres ontvang je een nieuwe bevestigingsmail.'
 All: Alle
@@ -27,6 +28,7 @@ All: Alle
 'Are you sure you want to delete this elimination?': 'Weet je zeker dat je deze eliminatie wilt verwijderen?'
 'Are you sure you want to delete this question from the question bank?': 'Weet je zeker dat je deze vraag uit de vragenbank wilt verwijderen?'
 'Are you sure you want to delete this quiz?': 'Weet je zeker dat je deze test wilt verwijderen?'
+'Are you sure you want to remove {email} as an owner of this season?': 'Weet je zeker dat je {email} wilt verwijderen als eigenaar van dit seizoen?'
 'Are you sure you want to reset progress for this candidate? Their given answers for this quiz will be deleted.': 'Weet je zeker dat je de voortgang van deze kandidaat wilt resetten? De ingevulde antwoorden voor deze test worden verwijderd.'
 Assign: Toewijzen
 Back: Terug
@@ -43,6 +45,7 @@ Candidate: Kandidaat
 'Candidate renamed': 'Kandidaat hernoemd'
 'Candidate status updated': 'Kandidaatstatus bijgewerkt'
 Candidates: Kandidaten
+'Cannot remove the last owner of a season': 'Je kunt de laatste eigenaar van een seizoen niet verwijderen'
 'Change email': 'E-mailadres wijzigen'
 'Change password': 'Wachtwoord wijzigen'
 'Check your email': 'Controleer je e-mail'
@@ -77,7 +80,10 @@ Delete: Verwijderen
 'Delete Quiz...': 'Test verwijderen...'
 'Delete account': 'Account verwijderen'
 'Delete account...': 'Account verwijderen...'
+'Delete season': 'Seizoen verwijderen'
+'Delete season...': 'Seizoen verwijderen...'
 Delete...: Verwijderen...
+'Deleting this season permanently removes it, its tests, and all candidate answers. This cannot be undone.': 'Als je dit seizoen verwijdert, worden ook alle tests en antwoorden van kandidaten definitief verwijderd. Dit kan niet ongedaan worden gemaakt.'
 'Deleting your account also deletes every season you are the only owner of. This cannot be undone.': 'Als je je account verwijdert, worden ook alle seizoenen verwijderd waarvan jij de enige eigenaar bent. Dit kan niet ongedaan worden gemaakt.'
 Done: Klaar
 'Download Template': 'Download sjabloon'
@@ -91,6 +97,7 @@ Edit: Bewerken
 'Elimination deleted': 'Eliminatie verwijderd'
 'Elimination updated': 'Eliminatie bijgewerkt'
 Email: E-mail
+'Email address': E-mailadres
 'Enter name': 'Voer een naam in'
 'Enter your email address, and we will send you a link to reset your password.': 'Voer je e-mailadres in en we sturen je een link om je wachtwoord te resetten.'
 'Enter your name': 'Voer je naam in'
@@ -122,6 +129,8 @@ Inactive: Inactief
 Labels: Labels
 Language: Taal
 'Language saved': 'Taal opgeslagen'
+'Leave season': 'Seizoen verlaten'
+'Leaving this season removes your ownership. You need at least one other owner before you can leave.': 'Als je dit seizoen verlaat, ben je geen eigenaar meer. Er moet minimaal één andere eigenaar zijn voordat je kunt vertrekken.'
 'Load Prepared Elimination': 'Laad voorbereide eliminatie'
 'Locked (answers given)': 'Vergrendeld (antwoorden gegeven)'
 'Locks the quiz so it can no longer be edited and makes it ready for candidates to take.': 'Vergrendelt de test zodat deze niet meer bewerkt kan worden en maakt deze klaar voor deelnemers.'
@@ -142,6 +151,7 @@ Next: Volgende
 'No questions in the question bank yet': 'Nog geen vragen in de vragenbank'
 'No quizzes': 'Geen tests'
 'No results': 'Geen resultaten'
+'No user found with this email address': 'Geen gebruiker gevonden met dit e-mailadres'
 'Not Started': 'Niet gestart'
 'Not confirmed': 'Niet bevestigd'
 'Number of dropouts:': 'Aantal afvallers:'
@@ -149,7 +159,10 @@ Next: Volgende
 Open: Openen
 'Order saved': 'Volgorde opgeslagen'
 Overview: Overzicht
+'Owner added': 'Eigenaar toegevoegd'
+'Owner removed': 'Eigenaar verwijderd'
 Owner(s): Eigenaar/Eigenaren
+Owners: Eigenaren
 Password: Wachtwoord
 Penalty: Straftijd
 'Please Confirm': 'Bevestig alsjeblieft'
@@ -197,6 +210,7 @@ Red: Rood
 Register: Registreren
 Releases: Releases
 'Remember me': 'Onthoud mij'
+Remove: Verwijderen
 'Remove label': 'Label verwijderen'
 Rename: Hernoemen
 'Rename candidate': 'Kandidaat hernoemen'
@@ -219,6 +233,7 @@ Season: Seizoen
 'Season Name': Seizoennaam
 'Season code': Seizoenscode
 'Season code regenerated': 'Seizoenscode opnieuw gegenereerd'
+'Season deleted': 'Seizoen verwijderd'
 'Season renamed': 'Seizoen hernoemd'
 Seasons: Seizoenen
 'Send password reset email': 'Stuur reset-e-mail'
@@ -249,6 +264,7 @@ Submit: Verstuur
 'This deletes your account and every season you are the only owner of. Enter your password to confirm.': 'Dit verwijdert je account en alle seizoenen waarvan jij de enige eigenaar bent. Vul je wachtwoord in om te bevestigen.'
 'This invalidates the current season code. Anyone using the old code will no longer be able to join this season.': 'Hiermee wordt de huidige seizoenscode ongeldig. Iedereen die de oude code gebruikt, kan dit seizoen niet meer vinden.'
 'This link will expire in {count}.': 'Deze link verloopt over {count}.'
+'This permanently deletes this season, its tests, and all candidate answers. This cannot be undone.': 'Dit verwijdert dit seizoen, de tests en alle antwoorden van kandidaten definitief. Dit kan niet ongedaan worden gemaakt.'
 'This question cannot be deleted because it is used in a locked or active quiz': 'Deze vraag kan niet verwijderd worden omdat die gebruik wordt in een vergrendelde of actieve test'
 'This question has already been used': 'Deze vraag is al gebruikt'
 'This question has been used in a quiz. The copy in the quiz will not be affected.': 'Deze vraag is gebruikt in een test. De kopie in de test blijft ongewijzigd.'
@@ -256,8 +272,11 @@ Submit: Verstuur
 'This quiz can no longer be altered': 'Deze test kan niet meer aangepast worden'
 'This quiz has already been filled in and can no longer be altered': 'Deze quiz is al ingevuld en kan niet meer worden gewijzigd'
 'This quiz has no questions yet': 'Deze test heeft nog geen vragen'
+'This user is already an owner of this season': 'Deze gebruiker is al eigenaar van dit seizoen'
 Time: Tijd
 'Toggle correct answer': 'Goed antwoord aan/uitzetten'
+"Type 'verwijderen' to confirm": "__Type 'verwijderen' to confirm"
+'Type {word} to confirm': 'Typ {word} om te bevestigen'
 Unassign: Ontkoppelen
 'Undo finalization': 'Afronden ongedaan maken'
 'Used in': 'Gebruikt in'
@@ -270,6 +289,7 @@ Yellow: Geel
 'You are not allowed to answer this quiz': 'Je mag deze test niet beantwoorden'
 'You cannot answer this question': 'Je kan deze vraag niet beantwoorden'
 'You have no seasons yet.': 'Je hebt nog geen seizoenen.'
+'You left the season': 'Je hebt het seizoen verlaten'
 'Your Seasons': 'Jouw seizoenen'
 'Your data': 'Je gegevens'
 'Your email address has been changed.': 'Je e-mailadres is gewijzigd.'


### PR DESCRIPTION
## Summary
- Season settings page now supports adding/removing owners by email (with a warning when no matching user exists), leaving a season (blocked when you're the last owner), and deleting a season via a type-to-confirm modal (closes #22).
- Deleting a season is a **soft delete**: `Season` is now `Gedmo\SoftDeleteable`, so the season and everything it owns (quizzes, candidates, answers, eliminations) stays in the database and can be recovered later — it's just hidden everywhere in the meantime.
- Permanent removal is reserved for GDPR account deletion. Fixed `UserRepository::deleteUser()` to also catch seasons a user had already soft-deleted before closing their account (the softdeleteable filter was hiding them from the purge), and to correctly hard-delete despite Season now being SoftDeleteable — Gedmo's listener persists the entity to record `deletedAt`, which was silently cancelling cascaded deletes of Quiz/Candidate/BankQuestion/QuestionLabel in the same flush; worked around by temporarily detaching the listener for that one flush.
- The GDPR data export now marks soft-deleted seasons with a "Deleted" timestamp (same pattern already used for `QuizCandidate`/`Elimination`) instead of silently omitting them.
- New `bo--type-to-confirm` Stimulus controller gates the delete-season submit button until "verwijderen" or "delete" is typed.
- Filed two follow-ups for what's intentionally out of scope here: #243 (restore a soft-deleted season) and #244 (scheduled job to purge soft-deleted seasons after a retention period).

## Test plan
- [x] `just test` (full suite, 353 tests)
- [x] `just phpstan`
- [x] `just fix-cs`
- [x] `just translations` (no further diff)
- [x] `just check-ts` / `deno test`
- [x] Manually verified in the browser: add owner (valid/unknown email), remove owner, leave season, soft-delete a season via the type-to-confirm modal (accepts both "verwijderen" and "delete") — confirmed it disappears from season listings but the row and its data survive, and the GDPR export still shows it marked as deleted