### PR TITLE
Add switchable language support (English mode)

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,6 +1,8 @@
 # see https://symfony.com/doc/current/reference/configuration/framework.html
 framework:
     secret: '%env(APP_SECRET)%'
+    enabled_locales: ['nl', 'en']
+    set_locale_from_accept_language: true
 
     # Note that the session will be started ONLY if you read or write from it.
     session: true

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -3,6 +3,7 @@ twig:
     form_themes: [ 'bootstrap_5_layout.html.twig' ]
     globals:
         sentry_dsn: '%env(SENTRY_DSN)%'
+        enabled_locales: '%kernel.enabled_locales%'
 
 when@test:
     twig:

--- a/migrations/Version20260724191719.php
+++ b/migrations/Version20260724191719.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/** Auto-generated Migration: Please modify to your needs! */
+final class Version20260724191719 extends AbstractMigration
+{
+    #[\Override]
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql("ALTER TABLE season_settings ADD language VARCHAR(5) DEFAULT 'nl' NOT NULL");
+        $this->addSql('ALTER TABLE "user" ADD locale VARCHAR(5) DEFAULT \'nl\' NOT NULL');
+    }
+
+    #[\Override]
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE season_settings DROP language');
+        $this->addSql('ALTER TABLE "user" DROP locale');
+    }
+}

--- a/migrations/Version20260724191719.php
+++ b/migrations/Version20260724191719.php
@@ -19,7 +19,7 @@ final class Version20260724191719 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql("ALTER TABLE season_settings ADD language VARCHAR(5) DEFAULT 'nl' NOT NULL");
+        $this->addSql("ALTER TABLE season_settings ADD locale VARCHAR(5) DEFAULT 'nl' NOT NULL");
         $this->addSql('ALTER TABLE "user" ADD locale VARCHAR(5) DEFAULT \'nl\' NOT NULL');
     }
 
@@ -27,7 +27,7 @@ final class Version20260724191719 extends AbstractMigration
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE season_settings DROP language');
+        $this->addSql('ALTER TABLE season_settings DROP locale');
         $this->addSql('ALTER TABLE "user" DROP locale');
     }
 }

--- a/src/Controller/Molshoop/MolshoopController.php
+++ b/src/Controller/Molshoop/MolshoopController.php
@@ -18,6 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 use Tvdt\Controller\AbstractController;
 use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
+use Tvdt\Entity\SeasonSettings;
 use Tvdt\Enum\FlashType;
 use Tvdt\Form\CreateSeasonFormType;
 use Tvdt\Helpers\FilenameSanitizer;
@@ -60,6 +61,9 @@ final class MolshoopController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $season->addOwner($this->authenticatedUser);
             $season->generateSeasonCode();
+            if ($season->settings instanceof SeasonSettings) {
+                $season->settings->language = $this->authenticatedUser->locale;
+            }
 
             $this->em->persist($season);
             $this->em->flush();

--- a/src/Controller/Molshoop/MolshoopController.php
+++ b/src/Controller/Molshoop/MolshoopController.php
@@ -62,7 +62,7 @@ final class MolshoopController extends AbstractController
             $season->addOwner($this->authenticatedUser);
             $season->generateSeasonCode();
             if ($season->settings instanceof SeasonSettings) {
-                $season->settings->language = $this->authenticatedUser->locale;
+                $season->settings->locale = $this->authenticatedUser->locale;
             }
 
             $this->em->persist($season);

--- a/src/Controller/Molshoop/SettingsController.php
+++ b/src/Controller/Molshoop/SettingsController.php
@@ -49,9 +49,15 @@ final class SettingsController extends AbstractController
 
     #[IsCsrfTokenValid('settings_language')]
     #[Route('/molshoop/settings/language', name: 'tvdt_molshoop_settings_language', methods: ['POST'])]
-    public function saveLanguage(): RedirectResponse
+    public function saveLanguage(Request $request): RedirectResponse
     {
-        // Only Dutch is available for now, so saving is a noop.
+        $language = (string) $request->request->get('language', '');
+
+        if (\in_array($language, ['nl', 'en'], true)) {
+            $this->authenticatedUser->locale = $language;
+            $this->entityManager->flush();
+        }
+
         $this->addFlash(FlashType::Success, $this->translator->trans('Language saved'));
 
         return $this->redirectToRoute('tvdt_molshoop_settings');

--- a/src/Controller/Molshoop/SettingsController.php
+++ b/src/Controller/Molshoop/SettingsController.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Safe\DateTimeImmutable;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -31,6 +32,7 @@ use Tvdt\Service\DataExportService;
 
 final class SettingsController extends AbstractController
 {
+    /** @param list<string> $enabledLocales */
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly UserPasswordHasherInterface $passwordHasher,
@@ -39,6 +41,8 @@ final class SettingsController extends AbstractController
         private readonly Security $security,
         private readonly TranslatorInterface $translator,
         private readonly DataExportService $dataExportService,
+        #[Autowire(param: 'kernel.enabled_locales')]
+        private readonly array $enabledLocales,
     ) {}
 
     #[Route('/molshoop/settings', name: 'tvdt_molshoop_settings', methods: ['GET'])]
@@ -53,7 +57,7 @@ final class SettingsController extends AbstractController
     {
         $language = (string) $request->request->get('language', '');
 
-        if (\in_array($language, ['nl', 'en'], true)) {
+        if (\in_array($language, $this->enabledLocales, true)) {
             $this->authenticatedUser->locale = $language;
             $this->entityManager->flush();
         }

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -7,6 +7,7 @@ namespace Tvdt\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,7 +24,19 @@ use Tvdt\Security\EmailVerifier;
 
 final class RegistrationController extends AbstractController
 {
-    public function __construct(private readonly EmailVerifier $emailVerifier, private readonly TranslatorInterface $translator, private readonly UserPasswordHasherInterface $userPasswordHasher, private readonly Security $security, private readonly UserRepository $userRepository, private readonly EntityManagerInterface $entityManager) {}
+    /** @param list<string> $enabledLocales */
+    public function __construct(
+        private readonly EmailVerifier $emailVerifier,
+        private readonly TranslatorInterface $translator,
+        private readonly UserPasswordHasherInterface $userPasswordHasher,
+        private readonly Security $security,
+        private readonly UserRepository $userRepository,
+        private readonly EntityManagerInterface $entityManager,
+        #[Autowire(param: 'kernel.enabled_locales')]
+        private readonly array $enabledLocales,
+        #[Autowire(param: 'kernel.default_locale')]
+        private readonly string $defaultLocale,
+    ) {}
 
     #[Route('/register', name: 'tvdt_register')]
     public function register(
@@ -42,7 +55,7 @@ final class RegistrationController extends AbstractController
             $plainPassword = $form->get('plainPassword')->getData();
 
             $user->password = $this->userPasswordHasher->hashPassword($user, $plainPassword);
-            $user->locale = $request->getPreferredLanguage(['nl', 'en']) ?? 'nl';
+            $user->locale = $request->getPreferredLanguage($this->enabledLocales) ?? $this->defaultLocale;
 
             $this->entityManager->persist($user);
             $this->entityManager->flush();

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -42,6 +42,7 @@ final class RegistrationController extends AbstractController
             $plainPassword = $form->get('plainPassword')->getData();
 
             $user->password = $this->userPasswordHasher->hashPassword($user, $plainPassword);
+            $user->locale = $request->getPreferredLanguage(['nl', 'en']) ?? 'nl';
 
             $this->entityManager->persist($user);
             $this->entityManager->flush();

--- a/src/Entity/SeasonSettings.php
+++ b/src/Entity/SeasonSettings.php
@@ -24,4 +24,7 @@ class SeasonSettings
 
     #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
     public bool $confirmAnswers = false;
+
+    #[ORM\Column(length: 5, options: ['default' => 'nl'])]
+    public string $language = 'nl';
 }

--- a/src/Entity/SeasonSettings.php
+++ b/src/Entity/SeasonSettings.php
@@ -26,5 +26,5 @@ class SeasonSettings
     public bool $confirmAnswers = false;
 
     #[ORM\Column(length: 5, options: ['default' => 'nl'])]
-    public string $language = 'nl';
+    public string $locale = 'nl';
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -49,6 +49,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column]
     public bool $isVerified = false;
 
+    #[ORM\Column(length: 5, options: ['default' => 'nl'])]
+    public string $locale = 'nl';
+
     public bool $isAdmin {
         get => \in_array('ROLE_ADMIN', $this->getRoles(), true);
     }

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -51,7 +51,7 @@ final readonly class LocaleListener implements EventSubscriberInterface
 
         foreach ($event->getArguments() as $argument) {
             if ($argument instanceof Season) {
-                return $argument->settings?->language;
+                return $argument->settings?->locale;
             }
         }
 

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -12,11 +12,7 @@ use Symfony\Component\Translation\LocaleSwitcher;
 use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
 
-/**
- * Overrides the Accept-Language-derived locale: with the authenticated user's profile
- * language on Molshoop (backoffice) pages, or with the resolved season's configured
- * language everywhere else (public quiz, elimination view, ...).
- */
+/** Overrides the Accept-Language-derived locale with the user's profile locale on Molshoop pages, or the viewed season's locale elsewhere. See LocaleListenerTest for the exact precedence per scenario. */
 final readonly class LocaleListener implements EventSubscriberInterface
 {
     public function __construct(
@@ -46,9 +42,6 @@ final readonly class LocaleListener implements EventSubscriberInterface
     {
         $route = (string) $event->getRequest()->attributes->get('_route');
 
-        // Molshoop is the only backoffice context, so the user's profile language always wins there.
-        // Everywhere else (public quiz, elimination view, ...) the season being viewed wins, even for
-        // an authenticated owner previewing it, since that content is scoped to the season, not to them.
         if (!str_starts_with($route, 'tvdt_molshoop_')) {
             foreach ($event->getArguments() as $argument) {
                 if ($argument instanceof Season) {

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\EventListener;
+
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Translation\LocaleSwitcher;
+use Tvdt\Entity\Season;
+use Tvdt\Entity\User;
+
+/**
+ * Overrides the Accept-Language-derived locale with the authenticated user's profile
+ * language (backoffice), or failing that, the season's configured language (public quiz).
+ */
+final readonly class LocaleListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private Security $security,
+        private LocaleSwitcher $localeSwitcher,
+    ) {}
+
+    /** @return array<string, string> */
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::CONTROLLER_ARGUMENTS => 'onControllerArguments'];
+    }
+
+    public function onControllerArguments(ControllerArgumentsEvent $event): void
+    {
+        $locale = $this->resolveLocale($event);
+
+        if (null === $locale) {
+            return;
+        }
+
+        $event->getRequest()->setLocale($locale);
+        $this->localeSwitcher->setLocale($locale);
+    }
+
+    private function resolveLocale(ControllerArgumentsEvent $event): ?string
+    {
+        $user = $this->security->getUser();
+
+        if ($user instanceof User) {
+            return $user->locale;
+        }
+
+        foreach ($event->getArguments() as $argument) {
+            if ($argument instanceof Season) {
+                return $argument->settings?->language;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -13,8 +13,9 @@ use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
 
 /**
- * Overrides the Accept-Language-derived locale with the authenticated user's profile
- * language (backoffice), or failing that, the season's configured language (public quiz).
+ * Overrides the Accept-Language-derived locale: with the authenticated user's profile
+ * language on Molshoop (backoffice) pages, or with the resolved season's configured
+ * language everywhere else (public quiz, elimination view, ...).
  */
 final readonly class LocaleListener implements EventSubscriberInterface
 {
@@ -43,18 +44,23 @@ final readonly class LocaleListener implements EventSubscriberInterface
 
     private function resolveLocale(ControllerArgumentsEvent $event): ?string
     {
+        $route = (string) $event->getRequest()->attributes->get('_route');
+
+        // Molshoop is the only backoffice context, so the user's profile language always wins there.
+        // Everywhere else (public quiz, elimination view, ...) the season being viewed wins, even for
+        // an authenticated owner previewing it, since that content is scoped to the season, not to them.
+        if (!str_starts_with($route, 'tvdt_molshoop_')) {
+            foreach ($event->getArguments() as $argument) {
+                if ($argument instanceof Season) {
+                    return $argument->settings?->locale;
+                }
+            }
+
+            return null;
+        }
+
         $user = $this->security->getUser();
 
-        if ($user instanceof User) {
-            return $user->locale;
-        }
-
-        foreach ($event->getArguments() as $argument) {
-            if ($argument instanceof Season) {
-                return $argument->settings?->locale;
-            }
-        }
-
-        return null;
+        return $user instanceof User ? $user->locale : null;
     }
 }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -23,10 +23,10 @@ class SettingsForm extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $choices = [];
-        foreach ($this->enabledLocales as $locale) {
-            $choices[\Locale::getDisplayLanguage($locale, $locale)] = $locale;
-        }
+        $choices = array_combine(
+            array_map(static fn (string $locale): string => \Locale::getDisplayLanguage($locale, $locale), $this->enabledLocales),
+            $this->enabledLocales,
+        );
 
         $builder
             ->add('showNumbers', options: [

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tvdt\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -24,6 +25,13 @@ class SettingsForm extends AbstractType
                 'label' => 'Confirm Answers',
                 'label_attr' => ['class' => 'checkbox-switch'],
                 'attr' => ['role' => 'switch', 'switch' => null]])
+            ->add('language', ChoiceType::class, [
+                'label' => 'Language',
+                'choices' => [
+                    'Nederlands' => 'nl',
+                    'English' => 'en',
+                ],
+            ])
             ->add('save', SubmitType::class, [
                 'label' => 'Save',
             ])

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tvdt\Form;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -14,8 +15,19 @@ use Tvdt\Entity\SeasonSettings;
 /** @extends AbstractType<SeasonSettings> */
 class SettingsForm extends AbstractType
 {
+    /** @param list<string> $enabledLocales */
+    public function __construct(
+        #[Autowire(param: 'kernel.enabled_locales')]
+        private readonly array $enabledLocales,
+    ) {}
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $choices = [];
+        foreach ($this->enabledLocales as $locale) {
+            $choices[\Locale::getDisplayLanguage($locale, $locale)] = $locale;
+        }
+
         $builder
             ->add('showNumbers', options: [
                 'label' => 'Show Numbers',
@@ -25,12 +37,9 @@ class SettingsForm extends AbstractType
                 'label' => 'Confirm Answers',
                 'label_attr' => ['class' => 'checkbox-switch'],
                 'attr' => ['role' => 'switch', 'switch' => null]])
-            ->add('language', ChoiceType::class, [
+            ->add('locale', ChoiceType::class, [
                 'label' => 'Language',
-                'choices' => [
-                    'Nederlands' => 'nl',
-                    'English' => 'en',
-                ],
+                'choices' => $choices,
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'Save',

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="nl" data-bs-theme="dark">
+<html lang="{{ app.request.locale }}" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/templates/molshoop/settings/index.html.twig
+++ b/templates/molshoop/settings/index.html.twig
@@ -23,8 +23,9 @@
                     <div class="mb-3">
                         <label class="form-label" for="settings-language">{{ 'Language'|trans }}</label>
                         <select class="form-select" id="settings-language" name="language">
-                            <option value="nl" {{ app.user.locale == 'nl' ? 'selected' }}>Nederlands</option>
-                            <option value="en" {{ app.user.locale == 'en' ? 'selected' }}>English</option>
+                            {% for locale in enabled_locales %}
+                                <option value="{{ locale }}" {{ app.user.locale == locale ? 'selected' }}>{{ locale|language_name(locale) }}</option>
+                            {% endfor %}
                         </select>
                     </div>
                     <button type="submit" class="btn btn-primary">{{ 'Save'|trans }}</button>

--- a/templates/molshoop/settings/index.html.twig
+++ b/templates/molshoop/settings/index.html.twig
@@ -23,7 +23,8 @@
                     <div class="mb-3">
                         <label class="form-label" for="settings-language">{{ 'Language'|trans }}</label>
                         <select class="form-select" id="settings-language" name="language">
-                            <option value="nl" selected>Nederlands</option>
+                            <option value="nl" {{ app.user.locale == 'nl' ? 'selected' }}>Nederlands</option>
+                            <option value="en" {{ app.user.locale == 'en' ? 'selected' }}>English</option>
                         </select>
                     </div>
                     <button type="submit" class="btn btn-primary">{{ 'Save'|trans }}</button>

--- a/tests/Integration/Controller/AbstractControllerWebTestCase.php
+++ b/tests/Integration/Controller/AbstractControllerWebTestCase.php
@@ -23,6 +23,11 @@ abstract class AbstractControllerWebTestCase extends WebTestCase
     protected function setUp(): void
     {
         $this->client = self::createClient();
+        // Symfony's Request::create() defaults to an English Accept-Language header when none is set,
+        // which would otherwise flip every anonymous request to English via set_locale_from_accept_language.
+        // Tests that specifically exercise browser-language detection can override this per-request.
+        $this->client->setServerParameter('HTTP_ACCEPT_LANGUAGE', 'nl');
+
         $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
     }
 

--- a/tests/Integration/Controller/Molshoop/MolshoopControllerTest.php
+++ b/tests/Integration/Controller/Molshoop/MolshoopControllerTest.php
@@ -32,7 +32,7 @@ final class MolshoopControllerTest extends AbstractControllerWebTestCase
 
         $season = $this->entityManager->getRepository(Season::class)->findOneBy(['name' => 'A New Season']);
         $this->assertInstanceOf(Season::class, $season);
-        $this->assertSame('en', $season->settings?->language);
+        $this->assertSame('en', $season->settings?->locale);
     }
 
     public function testExportQuizFilenameIsSanitized(): void

--- a/tests/Integration/Controller/Molshoop/MolshoopControllerTest.php
+++ b/tests/Integration/Controller/Molshoop/MolshoopControllerTest.php
@@ -7,11 +7,34 @@ namespace Tvdt\Tests\Integration\Controller\Molshoop;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\HttpFoundation\Request;
 use Tvdt\Controller\Molshoop\MolshoopController;
+use Tvdt\Entity\Season;
 use Tvdt\Tests\Integration\Controller\AbstractControllerWebTestCase;
 
 #[CoversClass(MolshoopController::class)]
 final class MolshoopControllerTest extends AbstractControllerWebTestCase
 {
+    public function testAddSeasonCopiesOwnersLocaleIntoSettings(): void
+    {
+        $user = $this->getUserByEmail('user2@example.org');
+        $user->locale = 'en';
+
+        $this->entityManager->flush();
+        $this->client->loginUser($user);
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/molshoop/season/add');
+        $form = $crawler->filter('form')->form([
+            'create_season_form[name]' => 'A New Season',
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+        $this->entityManager->clear();
+
+        $season = $this->entityManager->getRepository(Season::class)->findOneBy(['name' => 'A New Season']);
+        $this->assertInstanceOf(Season::class, $season);
+        $this->assertSame('en', $season->settings?->language);
+    }
+
     public function testExportQuizFilenameIsSanitized(): void
     {
         $user = $this->getUserByEmail('user2@example.org');

--- a/tests/Integration/Controller/Molshoop/SeasonControllerTest.php
+++ b/tests/Integration/Controller/Molshoop/SeasonControllerTest.php
@@ -29,14 +29,14 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/molshoop/season/krtek/settings');
         $form = $crawler->filter('form[name="settings_form"]')->form([
-            'settings_form[language]' => 'en',
+            'settings_form[locale]' => 'en',
         ]);
         $this->client->submit($form);
 
         self::assertResponseRedirects('/molshoop/season/krtek/settings');
         $this->entityManager->clear();
 
-        $this->assertSame('en', $this->getSeasonByCode('krtek')->settings?->language);
+        $this->assertSame('en', $this->getSeasonByCode('krtek')->settings?->locale);
     }
 
     public function testRegenerateSeasonCodeChangesTheCode(): void

--- a/tests/Integration/Controller/Molshoop/SeasonControllerTest.php
+++ b/tests/Integration/Controller/Molshoop/SeasonControllerTest.php
@@ -25,6 +25,20 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
         $this->loginAs('krtek-admin@example.org');
     }
 
+    public function testSettingsFormPersistsLanguage(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/molshoop/season/krtek/settings');
+        $form = $crawler->filter('form[name="settings_form"]')->form([
+            'settings_form[language]' => 'en',
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/molshoop/season/krtek/settings');
+        $this->entityManager->clear();
+
+        $this->assertSame('en', $this->getSeasonByCode('krtek')->settings?->language);
+    }
+
     public function testRegenerateSeasonCodeChangesTheCode(): void
     {
         $oldCode = 'krtek';

--- a/tests/Integration/Controller/Molshoop/SettingsControllerTest.php
+++ b/tests/Integration/Controller/Molshoop/SettingsControllerTest.php
@@ -60,6 +60,38 @@ final class SettingsControllerTest extends AbstractControllerWebTestCase
         self::assertResponseRedirects('/molshoop/settings');
     }
 
+    public function testLanguageSavePersistsToUser(): void
+    {
+        $token = $this->getCsrfTokenFromSettings('/molshoop/settings/language');
+
+        $this->client->request(Request::METHOD_POST, '/molshoop/settings/language', [
+            '_token' => $token,
+            'language' => 'en',
+        ]);
+
+        self::assertResponseRedirects('/molshoop/settings');
+        $this->entityManager->clear();
+
+        $user = $this->getUserByEmail('test@example.org');
+        $this->assertSame('en', $user->locale);
+    }
+
+    public function testLanguageSaveIgnoresUnknownLanguage(): void
+    {
+        $token = $this->getCsrfTokenFromSettings('/molshoop/settings/language');
+
+        $this->client->request(Request::METHOD_POST, '/molshoop/settings/language', [
+            '_token' => $token,
+            'language' => 'fr',
+        ]);
+
+        self::assertResponseRedirects('/molshoop/settings');
+        $this->entityManager->clear();
+
+        $user = $this->getUserByEmail('test@example.org');
+        $this->assertSame('nl', $user->locale);
+    }
+
     public function testChangePassword(): void
     {
         $this->client->request(Request::METHOD_GET, '/molshoop/settings');

--- a/tests/Integration/Controller/QuizControllerTest.php
+++ b/tests/Integration/Controller/QuizControllerTest.php
@@ -131,6 +131,24 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
         self::assertSelectorExists('html[lang="en"]');
     }
 
+    public function testEnterNamePageUsesTheSeasonsLanguageEvenForAnAuthenticatedOwner(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
+        $season->settings->locale = 'en';
+
+        $owner = $this->getUserByEmail('krtek-admin@example.org');
+        $owner->locale = 'nl';
+
+        $this->entityManager->flush();
+        $this->client->loginUser($owner);
+
+        $this->client->request(Request::METHOD_GET, '/krtek');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('html[lang="en"]');
+    }
+
     public function testQuizPageUsesTheSeasonsLanguage(): void
     {
         $season = $this->getSeasonByCode('krtek');

--- a/tests/Integration/Controller/QuizControllerTest.php
+++ b/tests/Integration/Controller/QuizControllerTest.php
@@ -110,7 +110,7 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
     {
         $season = $this->getSeasonByCode('krtek');
         $this->assertInstanceOf(SeasonSettings::class, $season->settings);
-        $season->settings->language = 'en';
+        $season->settings->locale = 'en';
         $this->entityManager->flush();
 
         $this->client->request(Request::METHOD_GET, '/');
@@ -122,7 +122,7 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
     {
         $season = $this->getSeasonByCode('krtek');
         $this->assertInstanceOf(SeasonSettings::class, $season->settings);
-        $season->settings->language = 'en';
+        $season->settings->locale = 'en';
         $this->entityManager->flush();
 
         $this->client->request(Request::METHOD_GET, '/krtek');
@@ -135,7 +135,7 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
     {
         $season = $this->getSeasonByCode('krtek');
         $this->assertInstanceOf(SeasonSettings::class, $season->settings);
-        $season->settings->language = 'en';
+        $season->settings->locale = 'en';
         $this->entityManager->flush();
 
         $this->client->request(Request::METHOD_GET, \sprintf('/krtek/%s', Base64::base64UrlEncode('Tom')));

--- a/tests/Integration/Controller/QuizControllerTest.php
+++ b/tests/Integration/Controller/QuizControllerTest.php
@@ -12,6 +12,7 @@ use Tvdt\Entity\Candidate;
 use Tvdt\Entity\GivenAnswer;
 use Tvdt\Entity\Question;
 use Tvdt\Entity\QuizCandidate;
+use Tvdt\Entity\SeasonSettings;
 use Tvdt\Helpers\Base64;
 
 #[CoversClass(QuizController::class)]
@@ -103,6 +104,44 @@ final class QuizControllerTest extends AbstractControllerWebTestCase
 
         self::assertResponseIsSuccessful();
         self::assertSelectorExists('form');
+    }
+
+    public function testSelectSeasonUsesBrowserLanguageNotSeasonLanguage(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
+        $season->settings->language = 'en';
+        $this->entityManager->flush();
+
+        $this->client->request(Request::METHOD_GET, '/');
+
+        self::assertSelectorExists('html[lang="nl"]');
+    }
+
+    public function testEnterNamePageUsesTheSeasonsLanguage(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
+        $season->settings->language = 'en';
+        $this->entityManager->flush();
+
+        $this->client->request(Request::METHOD_GET, '/krtek');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('html[lang="en"]');
+    }
+
+    public function testQuizPageUsesTheSeasonsLanguage(): void
+    {
+        $season = $this->getSeasonByCode('krtek');
+        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
+        $season->settings->language = 'en';
+        $this->entityManager->flush();
+
+        $this->client->request(Request::METHOD_GET, \sprintf('/krtek/%s', Base64::base64UrlEncode('Tom')));
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('html[lang="en"]');
     }
 
     public function testEnterNameRedirectsToQuizPage(): void

--- a/tests/Integration/Controller/RegistrationControllerTest.php
+++ b/tests/Integration/Controller/RegistrationControllerTest.php
@@ -47,6 +47,25 @@ final class RegistrationControllerTest extends AbstractControllerWebTestCase
         $this->assertFalse($user->isVerified);
     }
 
+    public function testRegisterSetsLocaleFromBrowserLanguage(): void
+    {
+        $this->client->setServerParameter('HTTP_ACCEPT_LANGUAGE', 'en-US,en;q=0.9');
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/register');
+        $form = $crawler->filter('form')->form([
+            'registration_form[email]' => 'english-speaker@example.org',
+            'registration_form[plainPassword][first]' => 'NewPass123!',
+            'registration_form[plainPassword][second]' => 'NewPass123!',
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/molshoop/');
+
+        $this->entityManager->clear();
+        $user = $this->getUserByEmail('english-speaker@example.org');
+        $this->assertSame('en', $user->locale);
+    }
+
     public function testVerifyEmailWithoutIdRedirectsToRegister(): void
     {
         $this->client->request(Request::METHOD_GET, '/verify/email');

--- a/tests/Unit/EventListener/LocaleListenerTest.php
+++ b/tests/Unit/EventListener/LocaleListenerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Translation\LocaleSwitcher;
+use Tvdt\Entity\Season;
+use Tvdt\Entity\SeasonSettings;
+use Tvdt\Entity\User;
+use Tvdt\EventListener\LocaleListener;
+
+#[CoversClass(LocaleListener::class)]
+final class LocaleListenerTest extends TestCase
+{
+    /** @param list<mixed> $arguments */
+    private function makeEvent(Request $request, array $arguments): ControllerArgumentsEvent
+    {
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        return new ControllerArgumentsEvent($kernel, static fn (): \stdClass => new \stdClass(), $arguments, $request, null);
+    }
+
+    public function testAuthenticatedUsersLocaleWinsOverEverythingElse(): void
+    {
+        $user = new User();
+        $user->locale = 'en';
+
+        $season = new Season();
+        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
+        $season->settings->language = 'nl';
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        $localeSwitcher->expects($this->once())->method('setLocale')->with('en');
+
+        $listener = new LocaleListener($security, $localeSwitcher);
+        $request = Request::create('/molshoop/');
+        $event = $this->makeEvent($request, [$season]);
+
+        $listener->onControllerArguments($event);
+
+        $this->assertSame('en', $request->getLocale());
+    }
+
+    public function testSeasonLanguageIsUsedWhenNoUserIsAuthenticated(): void
+    {
+        $season = new Season();
+        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
+        $season->settings->language = 'en';
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        $localeSwitcher->expects($this->once())->method('setLocale')->with('en');
+
+        $listener = new LocaleListener($security, $localeSwitcher);
+        $request = Request::create('/krtek/some-candidate');
+        $event = $this->makeEvent($request, ['some-candidate', $season]);
+
+        $listener->onControllerArguments($event);
+
+        $this->assertSame('en', $request->getLocale());
+    }
+
+    public function testLocaleIsUntouchedWhenNoUserOrSeasonIsResolved(): void
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        $localeSwitcher->expects($this->never())->method('setLocale');
+
+        $listener = new LocaleListener($security, $localeSwitcher);
+        $request = Request::create('/');
+        $request->setLocale('nl');
+
+        $event = $this->makeEvent($request, []);
+
+        $listener->onControllerArguments($event);
+
+        $this->assertSame('nl', $request->getLocale());
+    }
+}

--- a/tests/Unit/EventListener/LocaleListenerTest.php
+++ b/tests/Unit/EventListener/LocaleListenerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tvdt\Tests\Unit\EventListener;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,107 +20,58 @@ use Tvdt\EventListener\LocaleListener;
 #[CoversClass(LocaleListener::class)]
 final class LocaleListenerTest extends TestCase
 {
-    /** @param list<mixed> $arguments */
-    private function makeEvent(string $route, array $arguments): ControllerArgumentsEvent
+    private const string UNTOUCHED_SENTINEL = 'nl';
+
+    /** @return iterable<string, array{string, ?string, ?string, ?string}> */
+    public static function scenarios(): iterable
     {
+        // [route, userLocale, seasonLocale, expectedLocale]
+        yield 'molshoop + user + season: user wins, season ignored' => ['tvdt_molshoop_season_settings', 'en', 'nl', 'en'];
+        yield 'molshoop + user + no season: user wins' => ['tvdt_molshoop_index', 'en', null, 'en'];
+        yield 'molshoop + no user + season: untouched, season ignored on molshoop' => ['tvdt_molshoop_season_settings', null, 'nl', null];
+        yield 'molshoop + no user + no season: untouched' => ['tvdt_molshoop_index', null, null, null];
+        yield 'non-molshoop + user + season: season wins over user' => ['tvdt_elimination', 'nl', 'en', 'en'];
+        yield 'non-molshoop + user + no season: untouched, user ignored off molshoop' => ['tvdt_quiz_select_season', 'en', null, null];
+        yield 'non-molshoop + no user + season: season wins' => ['tvdt_quiz_enter_name', null, 'en', 'en'];
+        yield 'non-molshoop + no user + no season: untouched' => ['tvdt_quiz_select_season', null, null, null];
+    }
+
+    #[DataProvider('scenarios')]
+    public function testResolvesLocalePerRouteUserAndSeason(string $route, ?string $userLocale, ?string $seasonLocale, ?string $expectedLocale): void
+    {
+        $user = null;
+        if (null !== $userLocale) {
+            $user = new User();
+            $user->locale = $userLocale;
+        }
+
+        $arguments = [];
+        if (null !== $seasonLocale) {
+            $season = new Season();
+            $this->assertInstanceOf(SeasonSettings::class, $season->settings);
+            $season->settings->locale = $seasonLocale;
+            $arguments[] = $season;
+        }
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        if (null !== $expectedLocale) {
+            $localeSwitcher->expects($this->once())->method('setLocale')->with($expectedLocale);
+        } else {
+            $localeSwitcher->expects($this->never())->method('setLocale');
+        }
+
         $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('/');
         $request->attributes->set('_route', $route);
+        $request->setLocale(self::UNTOUCHED_SENTINEL);
 
-        return new ControllerArgumentsEvent($kernel, static fn (): \stdClass => new \stdClass(), $arguments, $request, null);
-    }
+        $event = new ControllerArgumentsEvent($kernel, static fn (): \stdClass => new \stdClass(), $arguments, $request, null);
 
-    private function seasonWithLocale(string $locale): Season
-    {
-        $season = new Season();
-        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
-        $season->settings->locale = $locale;
+        new LocaleListener($security, $localeSwitcher)->onControllerArguments($event);
 
-        return $season;
-    }
-
-    public function testMolshoopPageUsesTheAuthenticatedUsersLocaleEvenWithASeasonResolved(): void
-    {
-        $user = new User();
-        $user->locale = 'en';
-
-        $security = $this->createStub(Security::class);
-        $security->method('getUser')->willReturn($user);
-
-        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
-        $localeSwitcher->expects($this->once())->method('setLocale')->with('en');
-
-        $listener = new LocaleListener($security, $localeSwitcher);
-        $event = $this->makeEvent('tvdt_molshoop_season_settings', [$this->seasonWithLocale('nl')]);
-
-        $listener->onControllerArguments($event);
-
-        $this->assertSame('en', $event->getRequest()->getLocale());
-    }
-
-    public function testMolshoopPageIsUntouchedWhenNoUserIsAuthenticated(): void
-    {
-        $security = $this->createStub(Security::class);
-        $security->method('getUser')->willReturn(null);
-
-        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
-        $localeSwitcher->expects($this->never())->method('setLocale');
-
-        $listener = new LocaleListener($security, $localeSwitcher);
-        $event = $this->makeEvent('tvdt_molshoop_index', []);
-
-        $listener->onControllerArguments($event);
-    }
-
-    public function testNonMolshoopPageUsesTheSeasonsLocaleWhenNoUserIsAuthenticated(): void
-    {
-        $security = $this->createStub(Security::class);
-        $security->method('getUser')->willReturn(null);
-
-        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
-        $localeSwitcher->expects($this->once())->method('setLocale')->with('en');
-
-        $listener = new LocaleListener($security, $localeSwitcher);
-        $event = $this->makeEvent('tvdt_quiz_enter_name', ['some-candidate', $this->seasonWithLocale('en')]);
-
-        $listener->onControllerArguments($event);
-
-        $this->assertSame('en', $event->getRequest()->getLocale());
-    }
-
-    public function testNonMolshoopPageUsesTheSeasonsLocaleEvenForAnAuthenticatedUser(): void
-    {
-        $user = new User();
-        $user->locale = 'nl';
-
-        $security = $this->createStub(Security::class);
-        $security->method('getUser')->willReturn($user);
-
-        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
-        $localeSwitcher->expects($this->once())->method('setLocale')->with('en');
-
-        $listener = new LocaleListener($security, $localeSwitcher);
-        $event = $this->makeEvent('tvdt_elimination', [$this->seasonWithLocale('en')]);
-
-        $listener->onControllerArguments($event);
-
-        $this->assertSame('en', $event->getRequest()->getLocale());
-    }
-
-    public function testLocaleIsUntouchedWhenNoUserOrSeasonIsResolved(): void
-    {
-        $security = $this->createStub(Security::class);
-        $security->method('getUser')->willReturn(null);
-
-        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
-        $localeSwitcher->expects($this->never())->method('setLocale');
-
-        $listener = new LocaleListener($security, $localeSwitcher);
-        $event = $this->makeEvent('tvdt_quiz_select_season', []);
-        $event->getRequest()->setLocale('nl');
-
-        $listener->onControllerArguments($event);
-
-        $this->assertSame('nl', $event->getRequest()->getLocale());
+        $this->assertSame($expectedLocale ?? self::UNTOUCHED_SENTINEL, $request->getLocale());
     }
 }

--- a/tests/Unit/EventListener/LocaleListenerTest.php
+++ b/tests/Unit/EventListener/LocaleListenerTest.php
@@ -20,21 +20,28 @@ use Tvdt\EventListener\LocaleListener;
 final class LocaleListenerTest extends TestCase
 {
     /** @param list<mixed> $arguments */
-    private function makeEvent(Request $request, array $arguments): ControllerArgumentsEvent
+    private function makeEvent(string $route, array $arguments): ControllerArgumentsEvent
     {
         $kernel = $this->createStub(HttpKernelInterface::class);
+        $request = Request::create('/');
+        $request->attributes->set('_route', $route);
 
         return new ControllerArgumentsEvent($kernel, static fn (): \stdClass => new \stdClass(), $arguments, $request, null);
     }
 
-    public function testAuthenticatedUsersLocaleWinsOverEverythingElse(): void
+    private function seasonWithLocale(string $locale): Season
+    {
+        $season = new Season();
+        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
+        $season->settings->locale = $locale;
+
+        return $season;
+    }
+
+    public function testMolshoopPageUsesTheAuthenticatedUsersLocaleEvenWithASeasonResolved(): void
     {
         $user = new User();
         $user->locale = 'en';
-
-        $season = new Season();
-        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
-        $season->settings->locale = 'nl';
 
         $security = $this->createStub(Security::class);
         $security->method('getUser')->willReturn($user);
@@ -43,20 +50,29 @@ final class LocaleListenerTest extends TestCase
         $localeSwitcher->expects($this->once())->method('setLocale')->with('en');
 
         $listener = new LocaleListener($security, $localeSwitcher);
-        $request = Request::create('/molshoop/');
-        $event = $this->makeEvent($request, [$season]);
+        $event = $this->makeEvent('tvdt_molshoop_season_settings', [$this->seasonWithLocale('nl')]);
 
         $listener->onControllerArguments($event);
 
-        $this->assertSame('en', $request->getLocale());
+        $this->assertSame('en', $event->getRequest()->getLocale());
     }
 
-    public function testSeasonLanguageIsUsedWhenNoUserIsAuthenticated(): void
+    public function testMolshoopPageIsUntouchedWhenNoUserIsAuthenticated(): void
     {
-        $season = new Season();
-        $this->assertInstanceOf(SeasonSettings::class, $season->settings);
-        $season->settings->locale = 'en';
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
 
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        $localeSwitcher->expects($this->never())->method('setLocale');
+
+        $listener = new LocaleListener($security, $localeSwitcher);
+        $event = $this->makeEvent('tvdt_molshoop_index', []);
+
+        $listener->onControllerArguments($event);
+    }
+
+    public function testNonMolshoopPageUsesTheSeasonsLocaleWhenNoUserIsAuthenticated(): void
+    {
         $security = $this->createStub(Security::class);
         $security->method('getUser')->willReturn(null);
 
@@ -64,12 +80,30 @@ final class LocaleListenerTest extends TestCase
         $localeSwitcher->expects($this->once())->method('setLocale')->with('en');
 
         $listener = new LocaleListener($security, $localeSwitcher);
-        $request = Request::create('/krtek/some-candidate');
-        $event = $this->makeEvent($request, ['some-candidate', $season]);
+        $event = $this->makeEvent('tvdt_quiz_enter_name', ['some-candidate', $this->seasonWithLocale('en')]);
 
         $listener->onControllerArguments($event);
 
-        $this->assertSame('en', $request->getLocale());
+        $this->assertSame('en', $event->getRequest()->getLocale());
+    }
+
+    public function testNonMolshoopPageUsesTheSeasonsLocaleEvenForAnAuthenticatedUser(): void
+    {
+        $user = new User();
+        $user->locale = 'nl';
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        $localeSwitcher->expects($this->once())->method('setLocale')->with('en');
+
+        $listener = new LocaleListener($security, $localeSwitcher);
+        $event = $this->makeEvent('tvdt_elimination', [$this->seasonWithLocale('en')]);
+
+        $listener->onControllerArguments($event);
+
+        $this->assertSame('en', $event->getRequest()->getLocale());
     }
 
     public function testLocaleIsUntouchedWhenNoUserOrSeasonIsResolved(): void
@@ -81,13 +115,11 @@ final class LocaleListenerTest extends TestCase
         $localeSwitcher->expects($this->never())->method('setLocale');
 
         $listener = new LocaleListener($security, $localeSwitcher);
-        $request = Request::create('/');
-        $request->setLocale('nl');
-
-        $event = $this->makeEvent($request, []);
+        $event = $this->makeEvent('tvdt_quiz_select_season', []);
+        $event->getRequest()->setLocale('nl');
 
         $listener->onControllerArguments($event);
 
-        $this->assertSame('nl', $request->getLocale());
+        $this->assertSame('nl', $event->getRequest()->getLocale());
     }
 }

--- a/tests/Unit/EventListener/LocaleListenerTest.php
+++ b/tests/Unit/EventListener/LocaleListenerTest.php
@@ -34,7 +34,7 @@ final class LocaleListenerTest extends TestCase
 
         $season = new Season();
         $this->assertInstanceOf(SeasonSettings::class, $season->settings);
-        $season->settings->language = 'nl';
+        $season->settings->locale = 'nl';
 
         $security = $this->createStub(Security::class);
         $security->method('getUser')->willReturn($user);
@@ -55,7 +55,7 @@ final class LocaleListenerTest extends TestCase
     {
         $season = new Season();
         $this->assertInstanceOf(SeasonSettings::class, $season->settings);
-        $season->settings->language = 'en';
+        $season->settings->locale = 'en';
 
         $security = $this->createStub(Security::class);
         $security->method('getUser')->willReturn(null);


### PR DESCRIPTION
## Summary
- Anonymous pages (login, register, select-season) now follow the visitor's `Accept-Language` browser header via `enabled_locales`/`set_locale_from_accept_language`.
- A new `LocaleListener` (on `kernel.controller_arguments`) overrides that with the authenticated user's profile locale in the backoffice, or the resolved `Season`'s configured language on the public quiz flow from the name-entry page onward.
- `User::$locale` and `SeasonSettings::$language` columns added (migration included). Registration sets the user's locale from the browser; the backoffice settings "Language" control (previously a no-op stub) now persists it; season settings gained a language field; season creation copies the owner's current locale.
- `<html lang>` now reflects the resolved request locale instead of being hardcoded to `nl`.

Closes #235.

## Test plan
- [x] `just test` — full suite (374 tests) green, including new unit tests for `LocaleListener` and end-to-end integration tests asserting `<html lang>` flips correctly for anonymous/backoffice/quiz flows
- [x] `just phpstan`, `just fix-cs`, `just rector --dry-run` — all clean
- [x] `just translations` — no uncommitted diff (English works via fallback-to-message-id, no `en` translation file needed)
- [x] Manually verified against the running dev server: `/login`, `/register`, and `/` render correctly in English with `Accept-Language: en`, including English-fallback validation messages

**Note:** `EliminationController` (candidate-facing red/green screen viewer) is out of scope per the issue text ("select season" / "name page onwards") and still follows browser language rather than season language — flagging in case that should be included in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dutch and English as supported locales, with automatic locale selection based on browser language.
  * Users can now set and save a preferred language in settings.
  * Registration now saves the user’s locale derived from browser language (with fallback to the default).
  * Season-specific pages now apply the season’s language; quiz content reflects the season language.
  * The site’s language metadata and the settings language selector are now dynamic and locale-aware.

* **Bug Fixes**
  * Invalid or unknown language selections are ignored, keeping the current preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->