### PR TITLE
Add Auto/Light/Dark theme setting to Molshoop

### DIFF
--- a/assets/controllers/bo/theme_controller.ts
+++ b/assets/controllers/bo/theme_controller.ts
@@ -1,0 +1,62 @@
+import { Controller } from '@hotwired/stimulus';
+
+export const STORAGE_KEY = 'tvdt-theme';
+
+export type Theme = 'auto' | 'light' | 'dark';
+
+export function resolveEffectiveTheme(
+    theme: Theme,
+    prefersDark: boolean,
+): 'light' | 'dark' {
+    return theme === 'auto' ? (prefersDark ? 'dark' : 'light') : theme;
+}
+
+export default class extends Controller {
+    static targets = ['option'];
+
+    declare readonly optionTargets: HTMLElement[];
+
+    media = window.matchMedia('(prefers-color-scheme: dark)');
+
+    connect(): void {
+        this.syncActive();
+        this.media.addEventListener('change', this.onMediaChange);
+    }
+
+    disconnect(): void {
+        this.media.removeEventListener('change', this.onMediaChange);
+    }
+
+    select(event: Event): void {
+        const theme = (event.currentTarget as HTMLElement).dataset
+            .theme as Theme;
+        localStorage.setItem(STORAGE_KEY, theme);
+        this.apply(theme);
+    }
+
+    onMediaChange = (): void => {
+        if (this.currentTheme() === 'auto') this.apply('auto');
+    };
+
+    apply(theme: Theme): void {
+        document.documentElement.setAttribute(
+            'data-bs-theme',
+            resolveEffectiveTheme(theme, this.media.matches),
+        );
+        this.syncActive();
+    }
+
+    syncActive(): void {
+        const current = this.currentTheme();
+        this.optionTargets.forEach((option) => {
+            option.classList.toggle(
+                'active',
+                option.dataset.theme === current,
+            );
+        });
+    }
+
+    currentTheme(): Theme {
+        return (localStorage.getItem(STORAGE_KEY) as Theme | null) ?? 'auto';
+    }
+}

--- a/assets/controllers/bo/theme_controller.ts
+++ b/assets/controllers/bo/theme_controller.ts
@@ -11,15 +11,22 @@ export function resolveEffectiveTheme(
     return theme === 'auto' ? (prefersDark ? 'dark' : 'light') : theme;
 }
 
+const ICON_CLASSES: Record<Theme, string> = {
+    auto: 'bi-circle-half',
+    light: 'bi-sun-fill',
+    dark: 'bi-moon-stars-fill',
+};
+
 export default class extends Controller {
-    static targets = ['option'];
+    static targets = ['option', 'icon'];
 
     declare readonly optionTargets: HTMLElement[];
+    declare readonly iconTarget: HTMLElement;
 
     media = window.matchMedia('(prefers-color-scheme: dark)');
 
     connect(): void {
-        this.syncActive();
+        this.apply(this.currentTheme());
         this.media.addEventListener('change', this.onMediaChange);
     }
 
@@ -54,6 +61,7 @@ export default class extends Controller {
                 option.dataset.theme === current,
             );
         });
+        this.iconTarget.className = `bi ${ICON_CLASSES[current]}`;
     }
 
     currentTheme(): Theme {

--- a/assets/controllers/bo/theme_controller_test.ts
+++ b/assets/controllers/bo/theme_controller_test.ts
@@ -1,0 +1,12 @@
+import { assertEquals } from '@std/assert';
+import { resolveEffectiveTheme } from './theme_controller.ts';
+
+Deno.test('resolveEffectiveTheme follows the OS preference in auto mode', () => {
+    assertEquals(resolveEffectiveTheme('auto', true), 'dark');
+    assertEquals(resolveEffectiveTheme('auto', false), 'light');
+});
+
+Deno.test('resolveEffectiveTheme ignores the OS preference for explicit choices', () => {
+    assertEquals(resolveEffectiveTheme('light', true), 'light');
+    assertEquals(resolveEffectiveTheme('dark', false), 'dark');
+});

--- a/templates/molshoop/base.html.twig
+++ b/templates/molshoop/base.html.twig
@@ -4,14 +4,6 @@
 {% block head_extra %}
     <meta name="sentry-dsn" content="{{ sentry_dsn }}">
     <meta name="user-email" content="{{ app.user ? app.user.userIdentifier : '' }}">
-    <script>
-        (function () {
-            var theme = localStorage.getItem('tvdt-theme') || 'auto';
-            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            var effective = theme === 'auto' ? (prefersDark ? 'dark' : 'light') : theme;
-            document.documentElement.setAttribute('data-bs-theme', effective);
-        })();
-    </script>
 {% endblock %}
 {% block title %}Tijd voor de test | {% endblock %}
 {% block nav %}{{ include('molshoop/nav.html.twig') }}{% endblock %}

--- a/templates/molshoop/base.html.twig
+++ b/templates/molshoop/base.html.twig
@@ -4,6 +4,14 @@
 {% block head_extra %}
     <meta name="sentry-dsn" content="{{ sentry_dsn }}">
     <meta name="user-email" content="{{ app.user ? app.user.userIdentifier : '' }}">
+    <script>
+        (function () {
+            var theme = localStorage.getItem('tvdt-theme') || 'auto';
+            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            var effective = theme === 'auto' ? (prefersDark ? 'dark' : 'light') : theme;
+            document.documentElement.setAttribute('data-bs-theme', effective);
+        })();
+    </script>
 {% endblock %}
 {% block title %}Tijd voor de test | {% endblock %}
 {% block nav %}{{ include('molshoop/nav.html.twig') }}{% endblock %}

--- a/templates/molshoop/nav.html.twig
+++ b/templates/molshoop/nav.html.twig
@@ -41,11 +41,21 @@
                         </div>
                     </div>
                 </li>
+                {% if is_granted('IS_AUTHENTICATED') %}
+                    <li class="nav-item">
+                        <a class="nav-link{% if 'tvdt_molshoop_settings' == app.current_route() %} active{% endif %}"
+                           href="{{ path('tvdt_molshoop_settings') }}">{{ 'Settings'|trans }}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link"
+                           href="{{ path('tvdt_login_logout') }}">{{ 'Logout'|trans }}</a>
+                    </li>
+                {% endif %}
                 <li class="nav-item dropdown" data-controller="bo--theme">
                     <button type="button" class="nav-link dropdown-toggle border-0 bg-transparent"
                             data-bs-toggle="dropdown" aria-expanded="false"
                             aria-label="{{ 'Theme'|trans }}">
-                        <i class="bi bi-circle-half"></i>
+                        <i class="bi bi-circle-half" data-bo--theme-target="icon"></i>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-end">
                         <li>
@@ -71,16 +81,6 @@
                         </li>
                     </ul>
                 </li>
-                {% if is_granted('IS_AUTHENTICATED') %}
-                    <li class="nav-item">
-                        <a class="nav-link{% if 'tvdt_molshoop_settings' == app.current_route() %} active{% endif %}"
-                           href="{{ path('tvdt_molshoop_settings') }}">{{ 'Settings'|trans }}</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link"
-                           href="{{ path('tvdt_login_logout') }}">{{ 'Logout'|trans }}</a>
-                    </li>
-                {% endif %}
             </ul>
         </div>
     </div>

--- a/templates/molshoop/nav.html.twig
+++ b/templates/molshoop/nav.html.twig
@@ -41,6 +41,36 @@
                         </div>
                     </div>
                 </li>
+                <li class="nav-item dropdown" data-controller="bo--theme">
+                    <button type="button" class="nav-link dropdown-toggle border-0 bg-transparent"
+                            data-bs-toggle="dropdown" aria-expanded="false"
+                            aria-label="{{ 'Theme'|trans }}">
+                        <i class="bi bi-circle-half"></i>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                        <li>
+                            <button type="button" class="dropdown-item" data-theme="auto"
+                                    data-bo--theme-target="option"
+                                    data-action="click->bo--theme#select">
+                                <i class="bi bi-circle-half me-1"></i> {{ 'Auto'|trans }}
+                            </button>
+                        </li>
+                        <li>
+                            <button type="button" class="dropdown-item" data-theme="light"
+                                    data-bo--theme-target="option"
+                                    data-action="click->bo--theme#select">
+                                <i class="bi bi-sun-fill me-1"></i> {{ 'Light'|trans }}
+                            </button>
+                        </li>
+                        <li>
+                            <button type="button" class="dropdown-item" data-theme="dark"
+                                    data-bo--theme-target="option"
+                                    data-action="click->bo--theme#select">
+                                <i class="bi bi-moon-stars-fill me-1"></i> {{ 'Dark'|trans }}
+                            </button>
+                        </li>
+                    </ul>
+                </li>
                 {% if is_granted('IS_AUTHENTICATED') %}
                     <li class="nav-item">
                         <a class="nav-link{% if 'tvdt_molshoop_settings' == app.current_route() %} active{% endif %}"

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -31,6 +31,7 @@ All: Alle
 'Are you sure you want to remove {email} as an owner of this season?': 'Weet je zeker dat je {email} wilt verwijderen als eigenaar van dit seizoen?'
 'Are you sure you want to reset progress for this candidate? Their given answers for this quiz will be deleted.': 'Weet je zeker dat je de voortgang van deze kandidaat wilt resetten? De ingevulde antwoorden voor deze test worden verwijderd.'
 Assign: Toewijzen
+Auto: Automatisch
 Back: Terug
 'Back to login': 'Terug naar inloggen'
 Blue: Blauw
@@ -72,6 +73,7 @@ Create: Aanmaken
 'Current version': 'Huidige versie'
 Cyan: Cyaan
 'Danger zone': Gevarenzone
+Dark: Donker
 Deactivate: Deactiveren
 'Deactivate Quiz': 'Deactiveer test'
 'Deactivate the quiz before undoing the finalization': 'Deactiveer de test voordat je het afronden ongedaan maakt'
@@ -130,6 +132,7 @@ Language: Taal
 'Language saved': 'Taal opgeslagen'
 'Leave season': 'Seizoen verlaten'
 'Leaving this season removes your ownership. You need at least one other owner before you can leave.': 'Als je dit seizoen verlaat, ben je geen eigenaar meer. Er moet minimaal één andere eigenaar zijn voordat je kunt vertrekken.'
+Light: Licht
 'Load Prepared Elimination': 'Laad voorbereide eliminatie'
 'Locked (answers given)': 'Vergrendeld (antwoorden gegeven)'
 'Locks the quiz so it can no longer be edited and makes it ready for candidates to take.': 'Vergrendelt de test zodat deze niet meer bewerkt kan worden en maakt deze klaar voor deelnemers.'
@@ -257,6 +260,7 @@ Submit: Verstuur
 'The quiz name must be between 1 and 64 characters': 'De naam van de test moet tussen de 1 en 64 tekens zijn'
 'The season code is used by candidates to join this season. Regenerating it invalidates the current code, so make sure to share the new one.': 'De seizoenscode wordt door kandidaten gebruikt om dit seizoen te vinden. Als je een nieuwe code genereert, werkt de oude niet meer, dus deel de nieuwe code opnieuw.'
 'The season name must be between 1 and 64 characters': 'De naam van het seizoen moet tussen de 1 en 64 tekens zijn'
+Theme: Thema
 'There are no answers for this question': 'Er zijn geen antwoorden voor deze vraag'
 'There is already an account with this email': 'Er is al een account met dit e-mailadres'
 'There is no active quiz': 'Er is geen test actief'


### PR DESCRIPTION
## Summary
- Adds an Auto/Light/Dark theme dropdown to the Molshoop nav, using Bootstrap 5.3's native `data-bs-theme` color modes
- Choice persists in `localStorage` (`tvdt-theme`), defaulting to Auto (follows OS `prefers-color-scheme`)
- An inline script in Molshoop's `<head>` applies the stored/resolved theme before first paint to avoid a flash of the wrong theme
- Scoped to Molshoop only — the public quiz UI keeps its existing fixed dark styling (`base.html.twig`'s `data-bs-theme="dark"` default is untouched, quiz.scss hardcodes its own black background regardless of the attribute)

Closes #246

## Test plan
- [x] `just test-ts` — new `resolveEffectiveTheme` unit tests pass
- [x] `just check-ts` — deno fmt/lint/check clean
- [x] `just fix-cs` — PHP-CS-Fixer / Twig-CS-Fixer clean
- [x] `just phpstan` — no errors
- [x] `just translations` — idempotent after adding Dutch strings for Auto/Light/Dark/Theme
- [x] `just test` — full PHPUnit suite green (363 tests)
- [x] Manually verified in browser: toggle switches theme live, persists across a hard reload with no flash, active option highlighted correctly, and the public quiz page (`/krtek`) stays dark regardless of the stored Molshoop theme
