### PR TITLE
Add English translations for Molshoop help content

### DIFF
--- a/templates/molshoop/help/en/index.html.twig
+++ b/templates/molshoop/help/en/index.html.twig
@@ -1,0 +1,10 @@
+<h6>Getting started</h6>
+<p>Each season groups one game with all its tests and candidates. The season code is the link candidates use to start a test, and is only active while a test is active.</p>
+<h6>General workflow</h6>
+<ol>
+    <li><strong>Create a season</strong> and add candidates</li>
+    <li><strong>Create a test</strong> via Excel or the question bank</li>
+    <li><strong>Finalize</strong> and <strong>activate</strong> the test</li>
+    <li>Let candidates <strong>participate</strong> (own device or shared laptop)</li>
+    <li>View <strong>results</strong> and start the elimination</li>
+</ol>

--- a/templates/molshoop/help/en/prepare_elimination.html.twig
+++ b/templates/molshoop/help/en/prepare_elimination.html.twig
@@ -1,0 +1,3 @@
+<h6>Prepare elimination</h6>
+<p>Choose a colour for each candidate: <strong>green</strong> means safe, <strong>red</strong> means eliminated.</p>
+<p>Use <strong>Save and start</strong> to play the elimination right away, or save now and start it later from the Results tab.</p>

--- a/templates/molshoop/help/en/quiz_add.html.twig
+++ b/templates/molshoop/help/en/quiz_add.html.twig
@@ -1,0 +1,8 @@
+<h6>Import a test via Excel</h6>
+<p>Upload an Excel file with the questions for this test. After uploading, you can review the questions, check them, and finalize the test.</p>
+<h6>Expected format</h6>
+<ul>
+    <li>First column: the question text</li>
+    <li>Following columns: the answer options</li>
+    <li>Mark the correct answer with <strong>TRUE</strong> (English-language Excel) or <strong>WAAR</strong> (Dutch-language Excel), and set all other answers to FALSE/ONWAAR</li>
+</ul>

--- a/templates/molshoop/help/en/quiz_add.html.twig
+++ b/templates/molshoop/help/en/quiz_add.html.twig
@@ -1,5 +1,6 @@
 <h6>Import a test via Excel</h6>
 <p>Upload an Excel file with the questions for this test. After uploading, you can review the questions, check them, and finalize the test.</p>
+<p>Don't have a file yet? Use the <strong>Download Template</strong> button in the navigation bar to get a blank Excel file with the correct layout.</p>
 <h6>Expected format</h6>
 <ul>
     <li>First column: the question text</li>

--- a/templates/molshoop/help/en/quiz_add_blank.html.twig
+++ b/templates/molshoop/help/en/quiz_add_blank.html.twig
@@ -1,0 +1,3 @@
+<h6>Create a blank test</h6>
+<p>Create an empty test and add questions from the question bank. Handy if you're reusing questions or already have them ready in the bank.</p>
+<p>After creating it, open the test, add questions via the Overview tab, and finalize the test before activating it.</p>

--- a/templates/molshoop/help/en/quiz_answer_mapping.html.twig
+++ b/templates/molshoop/help/en/quiz_answer_mapping.html.twig
@@ -1,0 +1,3 @@
+<h6>Fill in answers</h6>
+<p>Use this form to assign answers to candidates. This makes it possible to generate statistics on how suspicious candidates are.</p>
+<p>Navigate between questions with the Previous and Next buttons. Check the given answer for each candidate and save.</p>

--- a/templates/molshoop/help/en/quiz_candidates.html.twig
+++ b/templates/molshoop/help/en/quiz_candidates.html.twig
@@ -1,0 +1,6 @@
+<h6>Let candidates participate</h6>
+<p>Candidates can fill in the test on their own device, one or more shared laptops, or a mix of both.</p>
+<p><strong>Own device:</strong> Share the season code. Each candidate visits the site on their own phone or laptop, enters their own name, and starts the test.</p>
+<p><strong>Shared laptop(s):</strong> Open the name entry page beforehand on one or more laptops. Each candidate types their name and starts. Afterwards, the next candidate can do the same on the same or another laptop.</p>
+<h6>Status</h6>
+<p>Deactivate a candidate if they don't need to take the test, for example after having already been eliminated earlier. Deactivation is per test and doesn't affect other tests.</p>

--- a/templates/molshoop/help/en/quiz_overview.html.twig
+++ b/templates/molshoop/help/en/quiz_overview.html.twig
@@ -1,5 +1,5 @@
 <h6>Overview &amp; finalizing</h6>
-<p>Questions with a red marker in the list next to it contain an error. Fix these before finalizing.</p>
+<p>Questions with a red marker in the list next to them contain an error. Fix these before finalizing.</p>
 <p><strong>Finalizing</strong> locks the test for editing and makes it ready for candidates. After that you can activate it.</p>
 <p><strong>Activating</strong> makes the test available to candidates. Only one test can be active at a time, so only activate the next one once everyone has finished the current one.</p>
 <p><strong>Clearing the test</strong> removes all given answers and undoes the finalization, so you can edit and run the test again.</p>

--- a/templates/molshoop/help/en/quiz_overview.html.twig
+++ b/templates/molshoop/help/en/quiz_overview.html.twig
@@ -1,0 +1,5 @@
+<h6>Overview &amp; finalizing</h6>
+<p>Questions with a red marker in the list next to it contain an error. Fix these before finalizing.</p>
+<p><strong>Finalizing</strong> locks the test for editing and makes it ready for candidates. After that you can activate it.</p>
+<p><strong>Activating</strong> makes the test available to candidates. Only one test can be active at a time, so only activate the next one once everyone has finished the current one.</p>
+<p><strong>Clearing the test</strong> removes all given answers and undoes the finalization, so you can edit and run the test again.</p>

--- a/templates/molshoop/help/en/quiz_question_bank_form.html.twig
+++ b/templates/molshoop/help/en/quiz_question_bank_form.html.twig
@@ -1,0 +1,4 @@
+<h6>Add question</h6>
+<p>Enter the question and add at least two answer options. Mark exactly one answer as correct.</p>
+<p>Use labels to organize questions in the question bank, for example by episode or question type.</p>
+<p>Mark a question as <em>reusable</em> if it may appear in multiple tests, otherwise a question can only be linked to a single test.</p>

--- a/templates/molshoop/help/en/quiz_result.html.twig
+++ b/templates/molshoop/help/en/quiz_result.html.twig
@@ -1,0 +1,5 @@
+<h6>Results</h6>
+<p>The table shows the final result per candidate, sorted by score. Red rows are the candidates with the lowest score, who are at risk of elimination.</p>
+<p><strong>Jokers</strong> are added for correct or incorrect questions (half points are possible).</p>
+<p><strong>Time penalty</strong> is a time penalty in seconds and is taken into account for tied scores. Note: a positive number is a penalty and a negative number is a bonus.</p>
+<p>Use <strong>Prepare elimination</strong> to set the screen colours manually and start the elimination.</p>

--- a/templates/molshoop/help/en/season_add.html.twig
+++ b/templates/molshoop/help/en/season_add.html.twig
@@ -1,0 +1,3 @@
+<h6>New season</h6>
+<p>A season groups all tests and candidates for one game. Give the season a recognizable name, the season code will be generated automatically.</p>
+<p>After creating it, you add candidates and create tests via the season page.</p>

--- a/templates/molshoop/help/en/season_add_candidates.html.twig
+++ b/templates/molshoop/help/en/season_add_candidates.html.twig
@@ -1,0 +1,3 @@
+<h6>Add candidates</h6>
+<p>Enter one name per line. These are the players taking part in this season.</p>
+<p>You can always add more candidates later via the Candidates tab. Use the same spelling of names that you use in the game.</p>

--- a/templates/molshoop/help/en/season_candidates.html.twig
+++ b/templates/molshoop/help/en/season_candidates.html.twig
@@ -1,0 +1,4 @@
+<h6>Candidates</h6>
+<p>These are the players in this season. Add all participants before starting the first test, candidates are automatically linked to new tests.</p>
+<p>Names can be entered freely, use the same spelling that you use in the game.</p>
+<p>Use the pencil icon to rename a candidate and the trash icon to remove one. Removing a candidate also discards all answers they've given.</p>

--- a/templates/molshoop/help/en/season_question_bank.html.twig
+++ b/templates/molshoop/help/en/season_question_bank.html.twig
@@ -1,0 +1,3 @@
+<h6>Question bank</h6>
+<p>The question bank is a library of questions that can be linked to multiple tests. Mark a question as <em>reusable</em> if it may appear in multiple tests (e.g. "Who is the Mole?").</p>
+<p>After editing a question in the bank, tests that already contain the question are <strong>not</strong> automatically updated, use the sync button (↻) next to a test to push through the latest version.</p>

--- a/templates/molshoop/help/en/season_settings.html.twig
+++ b/templates/molshoop/help/en/season_settings.html.twig
@@ -1,0 +1,4 @@
+<h6>Season settings</h6>
+<p>Adjust the display settings for this season here.</p>
+<p><strong>Show numbers:</strong> shows question numbers during the test. <strong>Confirm answer:</strong> asks candidates to confirm their answer before continuing.</p>
+<p><strong>Season code:</strong> the code candidates use to find this season. Generate a new code if the current one was accidentally shared, the old code will stop working afterwards.</p>

--- a/templates/molshoop/help/en/season_tests.html.twig
+++ b/templates/molshoop/help/en/season_tests.html.twig
@@ -1,0 +1,11 @@
+<h6>Manage tests</h6>
+<p>Add a test from an Excel file, or create a blank test and fill it in via the question bank. Then open the test to review it and finalize it.</p>
+<p>A test must be <strong>finalized</strong> before you can activate it. Only one test can be active at a time, namely the test candidates can currently fill in.</p>
+<h6>Order of operations</h6>
+<ol>
+    <li>Create a test (Excel or blank)</li>
+    <li>Check the questions and finalize the test</li>
+    <li>Activate the test</li>
+    <li>Let candidates participate</li>
+    <li>View results and prepare the elimination</li>
+</ol>

--- a/templates/molshoop/help/en/season_tests.html.twig
+++ b/templates/molshoop/help/en/season_tests.html.twig
@@ -1,6 +1,6 @@
 <h6>Manage tests</h6>
 <p>Add a test from an Excel file, or create a blank test and fill it in via the question bank. Then open the test to review it and finalize it.</p>
-<p>A test must be <strong>finalized</strong> before you can activate it. Only one test can be active at a time, namely the test candidates can currently fill in.</p>
+<p>A test must be <strong>finalized</strong> before you can activate it. Only one test can be active at a time, the test that candidates can currently fill in.</p>
 <h6>Order of operations</h6>
 <ol>
     <li>Create a test (Excel or blank)</li>

--- a/templates/molshoop/help/nl/quiz_add.html.twig
+++ b/templates/molshoop/help/nl/quiz_add.html.twig
@@ -1,5 +1,6 @@
 <h6>Test importeren via Excel</h6>
 <p>Upload een Excel-bestand met de vragen voor deze test. Na het uploaden kun je de vragen bekijken, controleren en de test afronden.</p>
+<p>Nog geen bestand? Gebruik de knop <strong>Download sjabloon</strong> in de navigatiebalk voor een leeg Excel-bestand met de juiste opmaak.</p>
 <h6>Verwacht formaat</h6>
 <ul>
     <li>Eerste kolom: de vraagtekst</li>


### PR DESCRIPTION
## Summary
- Adds an `en/` variant of every Molshoop help template (`templates/molshoop/help/en/*.html.twig`), mirroring the existing `nl/` set.
- The help dispatcher templates (`molshoop/help/*.html.twig`) already resolve `molshoop/help/{locale}/...` with an `nl/` fallback (added in #247), so English-mode users were silently seeing Dutch help text with no code change needed here — just the missing translations.

## Test plan
- [x] `just fix-cs` (Twig-CS-Fixer) passes on all new templates
- [ ] Spot-check a few help panels in the app with locale set to English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded English help content across seasons, candidates, question banks, tests, question importing, answer mapping, results, and elimination.
  * Added clear step-by-step workflows for creating and activating tests, running candidate participation, and preparing elimination.
  * Included guidance on quiz/test finalisation vs activation, scoring indicators (including jokers and time penalties), and season/test settings.
  * Added Dutch guidance for downloading an Excel template when no upload exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->