### PR TITLE
Improve XLSX import error messages for invalid boolean values

### DIFF
--- a/src/Controller/Molshoop/SeasonController.php
+++ b/src/Controller/Molshoop/SeasonController.php
@@ -28,6 +28,7 @@ use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
 use Tvdt\Enum\FlashType;
+use Tvdt\Exception\SpreadsheetDataException;
 use Tvdt\Form\AddCandidatesFormType;
 use Tvdt\Form\SettingsForm;
 use Tvdt\Form\UploadQuizFormType;
@@ -359,7 +360,15 @@ class SeasonController extends AbstractController
             /* @var UploadedFile $sheet */
             $sheet = $form->get('sheet')->getData();
 
-            $this->quizSpreadsheet->xlsxToQuiz($quiz, $sheet);
+            try {
+                $this->quizSpreadsheet->xlsxToQuiz($quiz, $sheet);
+            } catch (SpreadsheetDataException $spreadsheetDataException) {
+                foreach ($spreadsheetDataException->errors as $error) {
+                    $this->addFlash(FlashType::Danger, $error);
+                }
+
+                return $this->redirectToRoute('tvdt_molshoop_quiz_add', ['seasonCode' => $season->seasonCode]);
+            }
 
             $quiz->season = $season;
             $this->em->persist($quiz);

--- a/src/Service/QuizSpreadsheetService.php
+++ b/src/Service/QuizSpreadsheetService.php
@@ -83,7 +83,7 @@ class QuizSpreadsheetService
     }
 
     /**
-     * @param array<int, array<int, string|bool|null>> $sheet
+     * @param array<int, array<int, string|bool|int|float|null>> $sheet
      *
      * @throws SpreadsheetDataException
      */
@@ -105,7 +105,21 @@ class QuizSpreadsheetService
             $arrCounter = 1;
 
             while (\array_key_exists($arrCounter, $questionArr) && null !== $questionArr[$arrCounter]) {
-                $answer = new Answer((string) $questionArr[$arrCounter++], (bool) $questionArr[$arrCounter++]);
+                $text = (string) $questionArr[$arrCounter++];
+                $correctValue = $questionArr[$arrCounter++];
+                $isRightAnswer = $this->parseBoolean($correctValue);
+
+                if (null === $isRightAnswer) {
+                    $errors[] = \sprintf(
+                        'Question %d, answer %d: "%s" is not a valid value for the Correct column, expected TRUE/FALSE or WAAR/ONWAAR',
+                        $question->ordering,
+                        $answerCounter,
+                        (string) $correctValue,
+                    );
+                    $isRightAnswer = false;
+                }
+
+                $answer = new Answer($text, $isRightAnswer);
                 $answer->ordering = $answerCounter++;
                 $question->addAnswer($answer);
             }
@@ -120,6 +134,27 @@ class QuizSpreadsheetService
         if ([] !== $errors) {
             throw new SpreadsheetDataException($errors);
         }
+    }
+
+    private function parseBoolean(mixed $value): ?bool
+    {
+        if (\is_bool($value)) {
+            return $value;
+        }
+
+        if (\is_int($value) || \is_float($value)) {
+            return match ((float) $value) {
+                1.0 => true,
+                0.0 => false,
+                default => null,
+            };
+        }
+
+        return match (mb_strtoupper((string) $value)) {
+            'TRUE', 'WAAR' => true,
+            'FALSE', 'ONWAAR' => false,
+            default => null,
+        };
     }
 
     public function quizToXlsx(Quiz $quiz): \Closure

--- a/src/Service/QuizSpreadsheetService.php
+++ b/src/Service/QuizSpreadsheetService.php
@@ -92,8 +92,18 @@ class QuizSpreadsheetService
         $errors = [];
 
         $questionCounter = 1;
-        foreach ($sheet as $questionArr) {
+        foreach ($sheet as $rowIndex => $questionArr) {
             if (null === $questionArr[0]) {
+                $laterRowIndex = $this->findNextRowIndexWithAQuestion($sheet, $rowIndex + 1);
+
+                if (null !== $laterRowIndex) {
+                    $errors[] = \sprintf(
+                        'Row %d is blank, but row %d still contains a question; remove the blank row, or the questions after it will be ignored',
+                        $rowIndex + 2,
+                        $laterRowIndex + 2,
+                    );
+                }
+
                 break;
             }
 
@@ -103,14 +113,15 @@ class QuizSpreadsheetService
 
             $answerCounter = 1;
             $arrCounter = 1;
+            $invalidBooleanErrors = [];
 
             while (\array_key_exists($arrCounter, $questionArr) && null !== $questionArr[$arrCounter]) {
                 $text = (string) $questionArr[$arrCounter++];
-                $correctValue = $questionArr[$arrCounter++];
+                $correctValue = $questionArr[$arrCounter++] ?? null;
                 $isRightAnswer = $this->parseBoolean($correctValue);
 
                 if (null === $isRightAnswer) {
-                    $errors[] = \sprintf(
+                    $invalidBooleanErrors[] = \sprintf(
                         'Question %d, answer %d: "%s" is not a valid value for the Correct column, expected TRUE/FALSE or WAAR/ONWAAR',
                         $question->ordering,
                         $answerCounter,
@@ -124,8 +135,28 @@ class QuizSpreadsheetService
                 $question->addAnswer($answer);
             }
 
+            $answerCount = $answerCounter - 1;
+            if ($answerCount >= 2 && \count($invalidBooleanErrors) === $answerCount) {
+                $errors[] = \sprintf(
+                    'Question %d: none of its %d answers have a valid Correct value, its answer/Correct columns are probably missing or shifted',
+                    $question->ordering,
+                    $answerCount,
+                );
+            } else {
+                $errors = [...$errors, ...$invalidBooleanErrors];
+            }
+
             if (1 === $answerCounter) {
                 $errors[] = \sprintf('Question %d has no answers', $question->ordering);
+            }
+
+            $laterAnswerColumn = $this->findNextNonBlankColumn($questionArr, $arrCounter);
+            if (null !== $laterAnswerColumn) {
+                $errors[] = \sprintf(
+                    'Question %d: answer text is missing in column %s, so answers after it were ignored',
+                    $question->ordering,
+                    Coordinate::stringFromColumnIndex($laterAnswerColumn + 1),
+                );
             }
 
             $quiz->addQuestion($question);
@@ -134,6 +165,30 @@ class QuizSpreadsheetService
         if ([] !== $errors) {
             throw new SpreadsheetDataException($errors);
         }
+    }
+
+    /** @param array<int, array<int, string|bool|int|float|null>> $sheet */
+    private function findNextRowIndexWithAQuestion(array $sheet, int $fromRowIndex): ?int
+    {
+        foreach (\array_slice($sheet, $fromRowIndex, null, true) as $rowIndex => $row) {
+            if (null !== $row[0]) {
+                return $rowIndex;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<int, string|bool|int|float|null> $row */
+    private function findNextNonBlankColumn(array $row, int $fromColumn): ?int
+    {
+        for ($column = $fromColumn; \array_key_exists($column, $row); ++$column) {
+            if (null !== $row[$column]) {
+                return $column;
+            }
+        }
+
+        return null;
     }
 
     private function parseBoolean(mixed $value): ?bool

--- a/tests/Integration/Controller/Molshoop/SeasonControllerTest.php
+++ b/tests/Integration/Controller/Molshoop/SeasonControllerTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tvdt\Tests\Integration\Controller\Molshoop;
 
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\HttpFoundation\Request;
 use Tvdt\Controller\Molshoop\SeasonController;
@@ -14,6 +17,11 @@ use Tvdt\Entity\Quiz;
 use Tvdt\Entity\Season;
 use Tvdt\Enum\ScreenColour;
 use Tvdt\Tests\Integration\Controller\AbstractControllerWebTestCase;
+
+use function Safe\file_put_contents;
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
+use function Safe\unlink;
 
 #[CoversClass(SeasonController::class)]
 final class SeasonControllerTest extends AbstractControllerWebTestCase
@@ -392,5 +400,38 @@ final class SeasonControllerTest extends AbstractControllerWebTestCase
         ]);
 
         self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testAddQuizWithInvalidBooleanShowsErrorAndDoesNotPersist(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Question');
+        $sheet->setCellValue('B1', 'Answer 1');
+        $sheet->setCellValue('C1', 'Correct');
+        $sheet->setCellValue('A2', 'Who is de Mol?');
+        $sheet->setCellValue('B2', 'Alice');
+        $sheet->setCellValueExplicit('C2', 'onwar', DataType::TYPE_STRING);
+
+        $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('tvdt_test_', more_entropy: true).'.xlsx';
+        ob_start();
+        new Writer\Xlsx($spreadsheet)->save('php://output');
+        file_put_contents($path, ob_get_clean());
+
+        $this->client->request(Request::METHOD_GET, '/molshoop/season/krtek/add-quiz');
+        $form = $this->client->getCrawler()->filter('form')->form([
+            'upload_quiz_form[name]' => 'Broken quiz',
+            'upload_quiz_form[sheet]' => $path,
+        ]);
+        $this->client->submit($form);
+
+        unlink($path);
+
+        self::assertResponseRedirects('/molshoop/season/krtek/add-quiz');
+        $this->client->followRedirect();
+        $this->assertStringContainsString('onwar', (string) $this->client->getResponse()->getContent());
+
+        $this->entityManager->clear();
+        $this->assertNotInstanceOf(Quiz::class, $this->entityManager->getRepository(Quiz::class)->findOneBy(['name' => 'Broken quiz']));
     }
 }

--- a/tests/Unit/Service/QuizSpreadsheetServiceTest.php
+++ b/tests/Unit/Service/QuizSpreadsheetServiceTest.php
@@ -302,11 +302,20 @@ final class QuizSpreadsheetServiceTest extends TestCase
         } catch (SpreadsheetDataException $spreadsheetDataException) {
             $this->assertCount(1, $spreadsheetDataException->errors);
             $this->assertStringContainsString('onwar', $spreadsheetDataException->errors[0]);
+            $this->assertStringContainsString('TRUE/FALSE', $spreadsheetDataException->errors[0]);
             $this->assertStringContainsString('WAAR/ONWAAR', $spreadsheetDataException->errors[0]);
         }
     }
 
-    public function testXlsxToQuizDoesNotCrashOnNumericCorrectValue(): void
+    /** @return \Iterator<string, array{int, bool}> */
+    public static function numericBooleanProvider(): \Iterator
+    {
+        yield '1 is true' => [1, true];
+        yield '0 is false' => [0, false];
+    }
+
+    #[DataProvider('numericBooleanProvider')]
+    public function testXlsxToQuizDoesNotCrashOnNumericCorrectValue(int $value, bool $expected): void
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
@@ -315,7 +324,7 @@ final class QuizSpreadsheetServiceTest extends TestCase
         $sheet->setCellValue('C1', 'Correct');
         $sheet->setCellValue('A2', 'Who is de Mol?');
         $sheet->setCellValue('B2', 'Alice');
-        $sheet->setCellValue('C2', 1);
+        $sheet->setCellValue('C2', $value);
 
         $path = $this->createTempPath('.xlsx');
         ob_start();
@@ -329,7 +338,7 @@ final class QuizSpreadsheetServiceTest extends TestCase
         $question = $quiz->questions->first();
         /** @var Answer $answer */
         $answer = $question->answers->first();
-        $this->assertTrue($answer->isRightAnswer);
+        $this->assertSame($expected, $answer->isRightAnswer);
     }
 
     /** @return \Iterator<string, array{string, bool}> */
@@ -339,7 +348,10 @@ final class QuizSpreadsheetServiceTest extends TestCase
         yield 'FALSE' => ['FALSE', false];
         yield 'WAAR' => ['WAAR', true];
         yield 'ONWAAR' => ['ONWAAR', false];
+        yield 'lowercase true' => ['true', true];
+        yield 'lowercase false' => ['false', false];
         yield 'lowercase waar' => ['waar', true];
+        yield 'lowercase onwaar' => ['onwaar', false];
     }
 
     #[DataProvider('validBooleanTextProvider')]

--- a/tests/Unit/Service/QuizSpreadsheetServiceTest.php
+++ b/tests/Unit/Service/QuizSpreadsheetServiceTest.php
@@ -170,7 +170,7 @@ final class QuizSpreadsheetServiceTest extends TestCase
         }
     }
 
-    public function testXlsxToQuizStopsAtBlankRow(): void
+    public function testXlsxToQuizStopsSilentlyAtTrailingBlankRowWithNoFurtherData(): void
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
@@ -180,10 +180,7 @@ final class QuizSpreadsheetServiceTest extends TestCase
         $sheet->setCellValue('A2', 'First question');
         $sheet->setCellValue('B2', 'Yes');
         $sheet->setCellValue('C2', true);
-        // Row 3 intentionally blank — should halt parsing
-        $sheet->setCellValue('A4', 'Second question');
-        $sheet->setCellValue('B4', 'No');
-        $sheet->setCellValue('C4', false);
+        // Row 3 intentionally blank, and nothing follows it — a harmless trailing row.
 
         $path = $this->createTempPath('.xlsx');
         ob_start();
@@ -197,6 +194,90 @@ final class QuizSpreadsheetServiceTest extends TestCase
         /** @var Question $first */
         $first = $quiz->questions->first();
         $this->assertSame('First question', $first->question);
+    }
+
+    public function testXlsxToQuizThrowsWhenBlankRowIsFollowedByMoreQuestions(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Question');
+        $sheet->setCellValue('B1', 'Answer 1');
+        $sheet->setCellValue('C1', 'Correct');
+        $sheet->setCellValue('A2', 'First question');
+        $sheet->setCellValue('B2', 'Yes');
+        $sheet->setCellValue('C2', true);
+        // Row 3 intentionally blank, but row 4 still has data — likely an accidental gap.
+        $sheet->setCellValue('A4', 'Second question');
+        $sheet->setCellValue('B4', 'No');
+        $sheet->setCellValue('C4', false);
+
+        $path = $this->createTempPath('.xlsx');
+        ob_start();
+        new Writer\Xlsx($spreadsheet)->save('php://output');
+        file_put_contents($path, ob_get_clean());
+
+        try {
+            $this->subject->xlsxToQuiz(new Quiz(), new File($path));
+            $this->fail('Expected SpreadsheetDataException to be thrown');
+        } catch (SpreadsheetDataException $spreadsheetDataException) {
+            $this->assertCount(1, $spreadsheetDataException->errors);
+            $this->assertStringContainsString('Row 3', $spreadsheetDataException->errors[0]);
+            $this->assertStringContainsString('row 4', $spreadsheetDataException->errors[0]);
+        }
+    }
+
+    public function testXlsxToQuizThrowsWhenAGapHidesLaterAnswers(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Question');
+        $sheet->setCellValue('A2', 'Who is de Mol?');
+        $sheet->setCellValue('B2', 'Alice');
+        $sheet->setCellValue('C2', false);
+        // D2/E2 (answer 2) intentionally left blank, but answer 3 is filled in — a gap.
+        $sheet->setCellValue('F2', 'Charlie');
+        $sheet->setCellValue('G2', true);
+
+        $path = $this->createTempPath('.xlsx');
+        ob_start();
+        new Writer\Xlsx($spreadsheet)->save('php://output');
+        file_put_contents($path, ob_get_clean());
+
+        try {
+            $this->subject->xlsxToQuiz(new Quiz(), new File($path));
+            $this->fail('Expected SpreadsheetDataException to be thrown');
+        } catch (SpreadsheetDataException $spreadsheetDataException) {
+            $this->assertCount(1, $spreadsheetDataException->errors);
+            $this->assertStringContainsString('Question 1', $spreadsheetDataException->errors[0]);
+        }
+    }
+
+    public function testXlsxToQuizThrowsClearlyWhenTheCorrectColumnIsMissingEntirely(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Question');
+        $sheet->setCellValue('B1', 'Answer 1');
+        $sheet->setCellValue('C1', 'Answer 2');
+        $sheet->setCellValue('D1', 'Answer 3');
+        $sheet->setCellValue('A2', 'Who is de Mol?');
+        $sheet->setCellValue('B2', 'Alice');
+        $sheet->setCellValue('C2', 'Bob');
+        $sheet->setCellValue('D2', 'Charlie');
+
+        $path = $this->createTempPath('.xlsx');
+        ob_start();
+        new Writer\Xlsx($spreadsheet)->save('php://output');
+        file_put_contents($path, ob_get_clean());
+
+        try {
+            $this->subject->xlsxToQuiz(new Quiz(), new File($path));
+            $this->fail('Expected SpreadsheetDataException to be thrown');
+        } catch (SpreadsheetDataException $spreadsheetDataException) {
+            $this->assertCount(1, $spreadsheetDataException->errors);
+            $this->assertStringContainsString('Question 1', $spreadsheetDataException->errors[0]);
+            $this->assertStringContainsString('missing or shifted', $spreadsheetDataException->errors[0]);
+        }
     }
 
     public function testXlsxToQuizThrowsWithClearMessageOnInvalidBooleanValue(): void

--- a/tests/Unit/Service/QuizSpreadsheetServiceTest.php
+++ b/tests/Unit/Service/QuizSpreadsheetServiceTest.php
@@ -199,6 +199,95 @@ final class QuizSpreadsheetServiceTest extends TestCase
         $this->assertSame('First question', $first->question);
     }
 
+    public function testXlsxToQuizThrowsWithClearMessageOnInvalidBooleanValue(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Question');
+        $sheet->setCellValue('B1', 'Answer 1');
+        $sheet->setCellValue('C1', 'Correct');
+        $sheet->setCellValue('A2', 'Who is de Mol?');
+        $sheet->setCellValue('B2', 'Alice');
+        $sheet->setCellValueExplicit('C2', 'onwar', DataType::TYPE_STRING);
+
+        $path = $this->createTempPath('.xlsx');
+        ob_start();
+        new Writer\Xlsx($spreadsheet)->save('php://output');
+        file_put_contents($path, ob_get_clean());
+
+        try {
+            $this->subject->xlsxToQuiz(new Quiz(), new File($path));
+            $this->fail('Expected SpreadsheetDataException to be thrown');
+        } catch (SpreadsheetDataException $spreadsheetDataException) {
+            $this->assertCount(1, $spreadsheetDataException->errors);
+            $this->assertStringContainsString('onwar', $spreadsheetDataException->errors[0]);
+            $this->assertStringContainsString('WAAR/ONWAAR', $spreadsheetDataException->errors[0]);
+        }
+    }
+
+    public function testXlsxToQuizDoesNotCrashOnNumericCorrectValue(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Question');
+        $sheet->setCellValue('B1', 'Answer 1');
+        $sheet->setCellValue('C1', 'Correct');
+        $sheet->setCellValue('A2', 'Who is de Mol?');
+        $sheet->setCellValue('B2', 'Alice');
+        $sheet->setCellValue('C2', 1);
+
+        $path = $this->createTempPath('.xlsx');
+        ob_start();
+        new Writer\Xlsx($spreadsheet)->save('php://output');
+        file_put_contents($path, ob_get_clean());
+
+        $quiz = new Quiz();
+        $this->subject->xlsxToQuiz($quiz, new File($path));
+
+        /** @var Question $question */
+        $question = $quiz->questions->first();
+        /** @var Answer $answer */
+        $answer = $question->answers->first();
+        $this->assertTrue($answer->isRightAnswer);
+    }
+
+    /** @return \Iterator<string, array{string, bool}> */
+    public static function validBooleanTextProvider(): \Iterator
+    {
+        yield 'TRUE' => ['TRUE', true];
+        yield 'FALSE' => ['FALSE', false];
+        yield 'WAAR' => ['WAAR', true];
+        yield 'ONWAAR' => ['ONWAAR', false];
+        yield 'lowercase waar' => ['waar', true];
+    }
+
+    #[DataProvider('validBooleanTextProvider')]
+    public function testXlsxToQuizAcceptsBooleanValueTypedAsText(string $text, bool $expected): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Question');
+        $sheet->setCellValue('B1', 'Answer 1');
+        $sheet->setCellValue('C1', 'Correct');
+        $sheet->setCellValue('A2', 'Who is de Mol?');
+        $sheet->setCellValue('B2', 'Alice');
+        $sheet->setCellValueExplicit('C2', $text, DataType::TYPE_STRING);
+
+        $path = $this->createTempPath('.xlsx');
+        ob_start();
+        new Writer\Xlsx($spreadsheet)->save('php://output');
+        file_put_contents($path, ob_get_clean());
+
+        $quiz = new Quiz();
+        $this->subject->xlsxToQuiz($quiz, new File($path));
+
+        /** @var Question $question */
+        $question = $quiz->questions->first();
+        /** @var Answer $answer */
+        $answer = $question->answers->first();
+        $this->assertSame($expected, $answer->isRightAnswer);
+    }
+
     /** @return \Iterator<string, array{int, string, int, string, int, int}> */
     public static function answerCountHeaderProvider(): \Iterator
     {


### PR DESCRIPTION
## Summary
- The Correct column import previously used `(bool)` casting, which silently treated any non-empty string (e.g. text-typed `"ONWAAR"`/`"FALSE"`) as `true`, marking wrong answers as correct with no error. Added explicit validation accepting native booleans, numeric `1`/`0`, and case-insensitive `TRUE`/`FALSE`/`WAAR`/`ONWAAR`.
- **Missing/shifted Correct columns**: a sheet with only back-to-back answer text and no Correct column at all now gets one consolidated error ("its answer/Correct columns are probably missing or shifted") instead of confusingly blaming individual answer text as an invalid boolean.
- **Gaps inside a row**: a blank answer cell followed by more filled-in answers in the same row used to silently drop everything after the gap (including a possibly-correct answer) with zero feedback. Now reported explicitly.
- **Blank separator rows**: a blank row followed by more question rows used to silently discard all subsequent questions. Now reported explicitly — a genuinely trailing blank row with nothing after it still parses fine, unchanged.
- Fixed a latent "Undefined array key" PHP warning triggered when the Correct column was missing outright (fails the build under this project's `failOnWarning` PHPUnit config).
- **`SeasonController::addQuiz` never caught `SpreadsheetDataException`** — none of these error messages (old or new) ever reached the user; the import just crashed with a 500. Now caught and shown as flash errors, redirecting back to the upload form.
- Help templates (`templates/molshoop/help/{nl,en}/quiz_add.html.twig`) already document WAAR/ONWAAR vs TRUE/FALSE from earlier work, so no doc changes were needed here.

Fixes #177

## Test plan
- [x] New unit tests: invalid boolean text, valid text-typed TRUE/FALSE/WAAR/ONWAAR (any case), numeric 1/0, missing Correct column (structural message), mid-row gap, blank row with/without trailing data
- [x] New integration test: uploading a broken XLSX shows a flash error and does not persist a quiz
- [x] `just test` — full suite 393/393 pass
- [x] `just phpstan` — no errors
- [x] `just fix-cs` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quiz spreadsheet imports to robustly interpret the “Correct” column from booleans, numeric values, and Dutch/English TRUE/FALSE text variants.
  * Invalid “Correct” entries now generate clearer per-question error feedback, including guidance when the column is missing or shifted.
  * Improved handling for trailing/blank rows and answer gaps to prevent silent misreads and ignored questions.
* **Tests**
  * Expanded unit and integration coverage for parsing, error messaging, and confirmation that invalid uploads don’t persist quizzes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->