### PR TITLE
Add admin panel: user management, seasons overview, last activity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,35 @@ question counts as covered more than once).
 - Test fixtures in `src/DataFixtures/` (loaded with `--group=test`)
 - Test database configured separately via `.env.test`
 
+### Avoiding N+1 queries
+
+All associations in this codebase default to Doctrine's `LAZY` fetch mode (no entity declares `fetch: 'EAGER'`).
+Whenever a repository method returns a **list** of entities that a controller/template then iterates to read an
+association (a collection's `|length`, a `ManyToOne` field, `->map()` over owners, etc.), that association gets
+lazy-loaded **once per row** unless the repository explicitly eager-loads it — this is the classic N+1 pattern, and
+it's the single most common perf bug to introduce in this codebase.
+
+- **Be suspicious of `findAll()`/`findBy()`/`findOneBy()` feeding a list view.** They're the easiest way to introduce
+  N+1: they return fully-lazy entities with no eager-loaded associations, so any association access afterwards
+  (in a controller, a repository post-processing step, or a Twig template) triggers one query per row. If a list
+  view needs an association, add a dedicated repository method that eager-loads it instead of reaching for these
+  directly. They're still fine for single-entity lookups or callers that never touch an association on the result.
+- **Never join two collections in the same query.** Joining two `OneToMany`/`ManyToMany` collections on the same
+  root entity at once produces a cartesian product (row count = product of both collection sizes), corrupting
+  counts and wasting bandwidth even worse than N+1 would. Instead, run one main query, then one follow-up query
+  *per collection* using `select('partial root.{id}', 'assoc')` + `leftJoin` to populate each collection into the
+  identity map without duplicating rows. A `ManyToOne`/`OneToOne` (to-one) association has no such risk and can be
+  joined into the main query directly. See `BankQuestionRepository::findBySeason()` for the canonical multi-collection
+  version of this pattern, and `UserRepository::findAllForAdminOverview()` /
+  `SeasonRepository::findAllForAdminOverview()` for a simpler one-collection-plus-one-to-one version.
+- **Test it**: assert the query count doesn't grow when the row count does, using the profiler's `db` collector
+  rather than a fixed magic number tied to current fixture size — enable it with `$this->client->enableProfiler()`
+  before the request, then read `$this->client->getProfile()->getCollector('db')->getQueryCount()`. Insert extra
+  rows directly via the entity manager, make one more request, and assert the count stays flat (an equality
+  assertion between two `getQueryCount()` calls that straddle unrelated setup/insert work is unreliable — the `db`
+  collector accumulates everything logged on the connection since it was last read, so bracket the assertion
+  tightly around just the request being measured). See `AdminControllerTest`'s `*QueryCountDoesNotGrowWith*` tests.
+
 ### Testing Infrastructure
 
 - **PHPUnit 13** with DAMA Doctrine Test Bundle for transaction rollback

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,6 +22,7 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
+            - '../src/Rector/'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/migrations/Version20260726183231.php
+++ b/migrations/Version20260726183231.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/** Auto-generated Migration: Please modify to your needs! */
+final class Version20260726183231 extends AbstractMigration
+{
+    #[\Override]
+    public function getDescription(): string
+    {
+        return 'Add created (registration date) and last_activity to user';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Backfill existing rows to now() since their real registration date isn't known, then drop
+        // the default so the DB matches the ORM mapping (Gedmo\Timestampable sets it in PHP, no DB default).
+        $this->addSql('ALTER TABLE "user" ADD created TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL');
+        $this->addSql('ALTER TABLE "user" ALTER created DROP DEFAULT');
+        $this->addSql('ALTER TABLE "user" ADD last_activity TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL');
+    }
+
+    #[\Override]
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP created');
+        $this->addSql('ALTER TABLE "user" DROP last_activity');
+    }
+}

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -9,6 +9,7 @@ parameters:
         - tests/
     excludePaths:
         - config/reference.php
+        - rector.php
     treatPhpDocTypesAsCertain: false
     symfony:
         containerXmlPath: var/cache/dev/Tvdt_KernelDevDebugContainer.xml

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector;
 use Rector\Symfony\Bridge\Symfony\Routing\SymfonyRoutesProvider;
 use Rector\Symfony\Contract\Bridge\Symfony\Routing\SymfonyRoutesProviderInterface;
+use Tvdt\Rector\NoSafeNamespaceTypeHintRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -18,6 +19,7 @@ return RectorConfig::configure()
     ->withSymfonyContainerXml(__DIR__.'/var/cache/dev/Tvdt_KernelDevDebugContainer.xml')
     ->withSymfonyContainerPhp(__DIR__.'/tests/symfony-container.php')
     ->registerService(SymfonyRoutesProvider::class, SymfonyRoutesProviderInterface::class)
+    ->withRules([NoSafeNamespaceTypeHintRector::class])
     ->withParallel()
     ->withPhpSets()
     ->withPreparedSets(

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace Tvdt\Controller\Admin;
 
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
-use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 use Tvdt\Controller\AbstractController;
 use Tvdt\Entity\User;
 use Tvdt\Enum\FlashType;
 use Tvdt\Repository\SeasonRepository;
 use Tvdt\Repository\UserRepository;
+use Tvdt\Security\ResetPasswordMailer;
 
 #[AsController]
 #[IsGranted('ROLE_ADMIN')]
@@ -29,8 +29,7 @@ final class AdminController extends AbstractController
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly SeasonRepository $seasonRepository,
-        private readonly ResetPasswordHelperInterface $resetPasswordHelper,
-        private readonly MailerInterface $mailer,
+        private readonly ResetPasswordMailer $resetPasswordMailer,
         private readonly TranslatorInterface $translator,
     ) {}
 
@@ -68,20 +67,16 @@ final class AdminController extends AbstractController
         $this->userRepository->invalidateResetPasswordRequests($user);
 
         try {
-            $resetToken = $this->resetPasswordHelper->generateResetToken($user);
+            $resetToken = $this->resetPasswordMailer->send($user);
         } catch (ResetPasswordExceptionInterface) {
+            $resetToken = null;
+        }
+
+        if (!$resetToken instanceof ResetPasswordToken) {
             $this->addFlash(FlashType::Danger, $this->translator->trans('Could not send a password reset email to this user.'));
 
             return $this->redirectToRoute('tvdt_admin_users');
         }
-
-        $email = new TemplatedEmail()
-            ->to($user->getUserIdentifier())
-            ->subject($this->translator->trans('Your password reset request'))
-            ->htmlTemplate('reset_password/email.html.twig')
-            ->context(['resetToken' => $resetToken]);
-
-        $this->mailer->send($email);
 
         $this->addFlash(FlashType::Success, $this->translator->trans('A password reset email has been sent to this user.'));
 
@@ -95,10 +90,18 @@ final class AdminController extends AbstractController
         requirements: ['user' => Requirement::UUID],
         methods: ['POST'],
     )]
-    public function deleteUser(User $user): RedirectResponse
+    public function deleteUser(User $user, Request $request): RedirectResponse
     {
         if ($user === $this->authenticatedUser) {
             $this->addFlash(FlashType::Danger, $this->translator->trans('Use Settings to delete your own account.'));
+
+            return $this->redirectToRoute('tvdt_admin_users');
+        }
+
+        $confirmation = mb_strtolower(mb_trim($request->request->getString('confirmation')));
+
+        if (!\in_array($confirmation, ['verwijderen', 'delete'], true)) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('Type delete to confirm'));
 
             return $this->redirectToRoute('tvdt_admin_users');
         }

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Controller\Admin;
+
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
+use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+use Tvdt\Controller\AbstractController;
+use Tvdt\Entity\User;
+use Tvdt\Enum\FlashType;
+use Tvdt\Repository\SeasonRepository;
+use Tvdt\Repository\UserRepository;
+
+#[AsController]
+#[IsGranted('ROLE_ADMIN')]
+final class AdminController extends AbstractController
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly SeasonRepository $seasonRepository,
+        private readonly ResetPasswordHelperInterface $resetPasswordHelper,
+        private readonly MailerInterface $mailer,
+        private readonly TranslatorInterface $translator,
+    ) {}
+
+    #[Route('/admin', name: 'tvdt_admin_users', methods: ['GET'])]
+    public function users(): Response
+    {
+        return $this->render('admin/index.html.twig', [
+            'activeTab' => 'users',
+            'template' => 'admin/tab_users.html.twig',
+            'users' => $this->userRepository->findAll(),
+        ]);
+    }
+
+    #[Route('/admin/seasons', name: 'tvdt_admin_seasons', methods: ['GET'])]
+    public function seasons(): Response
+    {
+        return $this->render('admin/index.html.twig', [
+            'activeTab' => 'seasons',
+            'template' => 'admin/tab_seasons.html.twig',
+            'seasons' => $this->seasonRepository->findAll(),
+        ]);
+    }
+
+    #[IsCsrfTokenValid('admin_reset_password')]
+    #[Route(
+        '/admin/users/{user}/reset-password',
+        name: 'tvdt_admin_user_reset_password',
+        requirements: ['user' => Requirement::UUID],
+        methods: ['POST'],
+    )]
+    public function resetPassword(User $user): RedirectResponse
+    {
+        // An admin-triggered reset must not be blocked by the throttle that guards the user's own
+        // self-service request form (e.g. a user asking for support minutes after trying it themselves).
+        $this->userRepository->invalidateResetPasswordRequests($user);
+
+        try {
+            $resetToken = $this->resetPasswordHelper->generateResetToken($user);
+        } catch (ResetPasswordExceptionInterface) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('Could not send a password reset email to this user.'));
+
+            return $this->redirectToRoute('tvdt_admin_users');
+        }
+
+        $email = new TemplatedEmail()
+            ->to($user->getUserIdentifier())
+            ->subject($this->translator->trans('Your password reset request'))
+            ->htmlTemplate('reset_password/email.html.twig')
+            ->context(['resetToken' => $resetToken]);
+
+        $this->mailer->send($email);
+
+        $this->addFlash(FlashType::Success, $this->translator->trans('A password reset email has been sent to this user.'));
+
+        return $this->redirectToRoute('tvdt_admin_users');
+    }
+
+    #[IsCsrfTokenValid('admin_delete_user')]
+    #[Route(
+        '/admin/users/{user}/delete',
+        name: 'tvdt_admin_user_delete',
+        requirements: ['user' => Requirement::UUID],
+        methods: ['POST'],
+    )]
+    public function deleteUser(User $user): RedirectResponse
+    {
+        if ($user === $this->authenticatedUser) {
+            $this->addFlash(FlashType::Danger, $this->translator->trans('Use Settings to delete your own account.'));
+
+            return $this->redirectToRoute('tvdt_admin_users');
+        }
+
+        $this->userRepository->deleteUser($user);
+
+        $this->addFlash(FlashType::Success, $this->translator->trans('User deleted'));
+
+        return $this->redirectToRoute('tvdt_admin_users');
+    }
+}

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -40,7 +40,7 @@ final class AdminController extends AbstractController
         return $this->render('admin/index.html.twig', [
             'activeTab' => 'users',
             'template' => 'admin/tab_users.html.twig',
-            'users' => $this->userRepository->findAll(),
+            'users' => $this->userRepository->findAllForAdminOverview(),
         ]);
     }
 
@@ -50,7 +50,7 @@ final class AdminController extends AbstractController
         return $this->render('admin/index.html.twig', [
             'activeTab' => 'seasons',
             'template' => 'admin/tab_seasons.html.twig',
-            'seasons' => $this->seasonRepository->findAll(),
+            'seasons' => $this->seasonRepository->findAllForAdminOverview(),
         ]);
     }
 

--- a/src/Controller/Molshoop/MolshoopController.php
+++ b/src/Controller/Molshoop/MolshoopController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tvdt\Controller\Molshoop;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,7 +31,6 @@ final class MolshoopController extends AbstractController
 {
     public function __construct(
         private readonly SeasonRepository $seasonRepository,
-        private readonly Security $security,
         private readonly QuizSpreadsheetService $excel,
         private readonly EntityManagerInterface $em,
         private readonly TranslatorInterface $translator,
@@ -41,12 +39,8 @@ final class MolshoopController extends AbstractController
     #[Route('/molshoop/', name: 'tvdt_molshoop_index')]
     public function index(): Response
     {
-        $seasons = $this->security->isGranted('ROLE_ADMIN')
-            ? $this->seasonRepository->findAll()
-            : $this->seasonRepository->getSeasonsForUser($this->authenticatedUser);
-
         return $this->render('molshoop/index.html.twig', [
-            'seasons' => $seasons,
+            'seasons' => $this->seasonRepository->getSeasonsForUser($this->authenticatedUser),
         ]);
     }
 

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Tvdt\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -22,6 +20,7 @@ use Tvdt\Entity\User;
 use Tvdt\Enum\FlashType;
 use Tvdt\Form\ChangePasswordFormType;
 use Tvdt\Form\ResetPasswordRequestFormType;
+use Tvdt\Security\ResetPasswordMailer;
 
 final class ResetPasswordController extends AbstractController
 {
@@ -30,7 +29,7 @@ final class ResetPasswordController extends AbstractController
     public function __construct(
         private readonly ResetPasswordHelperInterface $resetPasswordHelper,
         private readonly EntityManagerInterface $entityManager,
-        private readonly MailerInterface $mailer,
+        private readonly ResetPasswordMailer $resetPasswordMailer,
         private readonly TranslatorInterface $translator,
         private readonly UserPasswordHasherInterface $passwordHasher,
     ) {}
@@ -47,7 +46,7 @@ final class ResetPasswordController extends AbstractController
             /** @var string $email */
             $email = $form->get('email')->getData();
 
-            return $this->processSendingPasswordResetEmail($email, $this->mailer, $this->translator);
+            return $this->processSendingPasswordResetEmail($email);
         }
 
         return $this->render('reset_password/request.html.twig', [
@@ -117,7 +116,7 @@ final class ResetPasswordController extends AbstractController
         ]);
     }
 
-    private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer, TranslatorInterface $translator): RedirectResponse
+    private function processSendingPasswordResetEmail(string $emailFormData): RedirectResponse
     {
         $user = $this->entityManager->getRepository(User::class)->findOneBy([
             'email' => $emailFormData,
@@ -128,20 +127,14 @@ final class ResetPasswordController extends AbstractController
         }
 
         try {
-            $resetToken = $this->resetPasswordHelper->generateResetToken($user);
+            $resetToken = $this->resetPasswordMailer->send($user);
         } catch (ResetPasswordExceptionInterface) {
             return $this->redirectToRoute('tvdt_check_email');
         }
 
-        $email = new TemplatedEmail()
-            ->to($user->getUserIdentifier())
-            ->subject($translator->trans('Your password reset request'))
-            ->htmlTemplate('reset_password/email.html.twig')
-            ->context([
-                'resetToken' => $resetToken,
-            ]);
-
-        $mailer->send($email);
+        if (!$resetToken instanceof ResetPasswordToken) {
+            return $this->redirectToRoute('tvdt_check_email');
+        }
 
         $this->setTokenObjectInSession($resetToken);
 

--- a/src/DataFixtures/TestFixtures.php
+++ b/src/DataFixtures/TestFixtures.php
@@ -23,6 +23,8 @@ final class TestFixtures extends Fixture implements FixtureGroupInterface, Depen
 {
     public const string PASSWORD = 'test1234';
 
+    public const string ADMIN_EMAIL = 'admin@example.org';
+
     public function __construct(
         private readonly UserPasswordHasherInterface $passwordHasher,
     ) {}
@@ -50,6 +52,13 @@ final class TestFixtures extends Fixture implements FixtureGroupInterface, Depen
         $user->password = $this->passwordHasher->hashPassword($user, self::PASSWORD);
 
         $manager->persist($user);
+
+        $admin = new User();
+        $admin->email = self::ADMIN_EMAIL;
+        $admin->password = $this->passwordHasher->hashPassword($admin, self::PASSWORD);
+        $admin->roles = ['ROLE_ADMIN'];
+
+        $manager->persist($admin);
 
         $krtek = $this->getReference(KrtekFixtures::KRTEK_SEASON, Season::class);
         $krtek->addOwner($user);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -51,6 +52,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column(length: 5, options: ['default' => 'nl'])]
     public string $locale = 'nl';
+
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: false)]
+    public private(set) \DateTimeImmutable $created;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true)]
+    public ?\DateTimeImmutable $lastActivity = null;
 
     public bool $isAdmin {
         get => \in_array('ROLE_ADMIN', $this->getRoles(), true);
@@ -101,15 +109,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         if (!$this->seasons->contains($season)) {
             $this->seasons->add($season);
             $season->addOwner($this);
-        }
-
-        return $this;
-    }
-
-    public function removeSeason(Season $season): static
-    {
-        if ($this->seasons->removeElement($season)) {
-            $season->removeOwner($this);
         }
 
         return $this;

--- a/src/EventListener/LastActivityListener.php
+++ b/src/EventListener/LastActivityListener.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Safe\DateTimeImmutable;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Tvdt\Entity\User;
+
+/** Records how recently a user was last seen, throttled so it costs at most one write per user per window. */
+final readonly class LastActivityListener implements EventSubscriberInterface
+{
+    // ponytail: per-user throttle window; lower it if "last activity" needs to be closer to real-time
+    private const int THROTTLE_SECONDS = 60;
+
+    public function __construct(
+        private Security $security,
+        private EntityManagerInterface $em,
+    ) {}
+
+    /** @return array<string, string> */
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::CONTROLLER => 'onKernelController'];
+    }
+
+    public function onKernelController(ControllerEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $now = new DateTimeImmutable();
+        if ($user->lastActivity instanceof \DateTimeImmutable
+            && $now->getTimestamp() - $user->lastActivity->getTimestamp() < self::THROTTLE_SECONDS) {
+            return;
+        }
+
+        $user->lastActivity = $now;
+        $this->em->flush();
+    }
+}

--- a/src/Rector/NoSafeNamespaceTypeHintRector.php
+++ b/src/Rector/NoSafeNamespaceTypeHintRector.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\ComplexType;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\UnionType;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Using Safe\ namespace classes in type hints or instanceof/is_a() checks is a mistake: callers may
+ * hold plain \DateTimeImmutable (or any other non-Safe subtype) and will get a type error at runtime.
+ * Safe\ classes extend their standard-library equivalents, so the parent class is always the right type.
+ */
+final class NoSafeNamespaceTypeHintRector extends AbstractRector
+{
+    public function __construct(private readonly ReflectionProvider $reflectionProvider) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace Safe\\ namespace type hints with their parent class to avoid rejecting compatible non-Safe objects',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                        class Foo
+                        {
+                            public ?\Safe\DateTimeImmutable $expiresAt;
+
+                            public function setDate(\Safe\DateTimeImmutable $date): void
+                            {
+                                if ($date instanceof \Safe\DateTimeImmutable) {
+                                    // ...
+                                }
+                                is_a($date, \Safe\DateTimeImmutable::class);
+                            }
+                        }
+                        CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                        class Foo
+                        {
+                            public ?\DateTimeImmutable $expiresAt;
+
+                            public function setDate(\DateTimeImmutable $date): void
+                            {
+                                if ($date instanceof \DateTimeImmutable) {
+                                    // ...
+                                }
+                                is_a($date, \DateTimeImmutable::class);
+                            }
+                        }
+                        CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [
+            Property::class,
+            Param::class,
+            Instanceof_::class,
+            FuncCall::class,
+        ];
+    }
+
+    /** @param Property|Param|Instanceof_|FuncCall $node */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof Property) {
+            return $this->refactorProperty($node);
+        }
+
+        if ($node instanceof Param) {
+            return $this->refactorParam($node);
+        }
+
+        if ($node instanceof Instanceof_) {
+            return $this->refactorInstanceof($node);
+        }
+
+        if ($node instanceof FuncCall) {
+            return $this->refactorIsA($node);
+        }
+
+        return null;
+    }
+
+    private function refactorProperty(Property $property): ?Property
+    {
+        if (!$property->type instanceof Node) {
+            return null;
+        }
+
+        $newType = $this->replaceType($property->type);
+        if (null === $newType) {
+            return null;
+        }
+
+        $property->type = $newType;
+
+        return $property;
+    }
+
+    private function refactorParam(Param $param): ?Param
+    {
+        if (!$param->type instanceof Node) {
+            return null;
+        }
+
+        $newType = $this->replaceType($param->type);
+        if (null === $newType) {
+            return null;
+        }
+
+        $param->type = $newType;
+
+        return $param;
+    }
+
+    private function refactorInstanceof(Instanceof_ $instanceof): ?Instanceof_
+    {
+        if (!$instanceof->class instanceof Name) {
+            return null;
+        }
+
+        $replacement = $this->resolveParentName($instanceof->class);
+        if (!$replacement instanceof FullyQualified) {
+            return null;
+        }
+
+        $instanceof->class = $replacement;
+
+        return $instanceof;
+    }
+
+    private function refactorIsA(FuncCall $funcCall): ?FuncCall
+    {
+        if (!$this->isNames($funcCall, ['is_a', 'is_subclass_of'])) {
+            return null;
+        }
+
+        if (!isset($funcCall->args[1]) || !$funcCall->args[1] instanceof Arg) {
+            return null;
+        }
+
+        $classArg = $funcCall->args[1]->value;
+
+        if ($classArg instanceof ClassConstFetch
+            && $classArg->class instanceof Name
+            && $classArg->name instanceof Identifier
+            && 'class' === $classArg->name->name
+        ) {
+            $replacement = $this->resolveParentName($classArg->class);
+            if (!$replacement instanceof FullyQualified) {
+                return null;
+            }
+
+            $classArg->class = $replacement;
+
+            return $funcCall;
+        }
+
+        if ($classArg instanceof String_) {
+            $className = mb_ltrim($classArg->value, '\\');
+            if (!str_starts_with($className, 'Safe\\')) {
+                return null;
+            }
+
+            $parentClass = $this->getParentClassName($className);
+            if (null === $parentClass) {
+                return null;
+            }
+
+            $classArg->value = '\\'.$parentClass;
+
+            return $funcCall;
+        }
+
+        return null;
+    }
+
+    /**
+     * Walks a type node and replaces any Safe\ class name with its parent class.
+     * Returns the modified node when a replacement was made, null otherwise.
+     */
+    private function replaceType(ComplexType|Identifier|Name $type): ComplexType|Name|null
+    {
+        if ($type instanceof Identifier) {
+            return null;
+        }
+
+        if ($type instanceof Name) {
+            return $this->resolveParentName($type);
+        }
+
+        if ($type instanceof NullableType) {
+            // A nullable type can only ever wrap a single Identifier|Name (PHP has no `?(A&B)` or
+            // `?(A|B)` syntax), so a Safe\X class there can only resolve to another plain Name.
+            $replaced = $this->replaceType($type->type);
+            if (!$replaced instanceof Name) {
+                return null;
+            }
+
+            $type->type = $replaced;
+
+            return $type;
+        }
+
+        if (!$type instanceof UnionType && !$type instanceof IntersectionType) {
+            return null;
+        }
+
+        // Each member can itself be Identifier|Name|IntersectionType (for UnionType) or
+        // Identifier|Name (for IntersectionType) — never NullableType/UnionType.
+        $changed = false;
+        foreach ($type->types as $i => $innerType) {
+            $replaced = $this->replaceType($innerType);
+            if ($replaced instanceof Name) {
+                $type->types[$i] = $replaced;
+                $changed = true;
+            }
+        }
+
+        return $changed ? $type : null;
+    }
+
+    /**
+     * Returns a FullyQualified parent class name if the given Name is in the Safe\ namespace,
+     * or null if no replacement is needed.
+     */
+    private function resolveParentName(Name $name): ?FullyQualified
+    {
+        $className = $name->toString();
+        if (!str_starts_with($className, 'Safe\\')) {
+            return null;
+        }
+
+        $parentClass = $this->getParentClassName($className);
+        if (null === $parentClass) {
+            return null;
+        }
+
+        return new FullyQualified($parentClass);
+    }
+
+    private function getParentClassName(string $safeClass): ?string
+    {
+        if (!$this->reflectionProvider->hasClass($safeClass)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($safeClass);
+        $parentReflection = $classReflection->getParentClass();
+
+        if (!$parentReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        return $parentReflection->getName();
+    }
+}

--- a/src/Repository/SeasonRepository.php
+++ b/src/Repository/SeasonRepository.php
@@ -43,6 +43,43 @@ class SeasonRepository extends ServiceEntityRepository
         )->setParameter('user', $user)->getResult();
     }
 
+    /** Every season, with $owners, $quizzes, and $activeQuiz already initialized so the admin
+     * overview's per-season owners/quiz-count/active-quiz columns don't trigger a lazy-loading
+     * query per row. $owners and $quizzes are hydrated in separate follow-up queries rather than
+     * joined together with the main query, to avoid the cartesian-product row explosion that
+     * occurs when joining multiple collections at once (see BankQuestionRepository::findBySeason()).
+     *
+     * @return list<Season>
+     */
+    public function findAllForAdminOverview(): array
+    {
+        /** @var list<Season> $seasons */
+        $seasons = $this->createQueryBuilder('s')
+            ->leftJoin('s.activeQuiz', 'aq')
+            ->addSelect('aq')
+            ->orderBy('s.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        if ([] === $seasons) {
+            return [];
+        }
+
+        $this->createQueryBuilder('s')
+            ->select('partial s.{id}', 'o')
+            ->leftJoin('s.owners', 'o')
+            ->getQuery()
+            ->getResult();
+
+        $this->createQueryBuilder('s')
+            ->select('partial s.{id}', 'q')
+            ->leftJoin('s.quizzes', 'q')
+            ->getQuery()
+            ->getResult();
+
+        return $seasons;
+    }
+
     /** Permanently deletes the season and every row tied to it — including the season itself,
      * which is Gedmo\SoftDeleteable and would otherwise only get its deletedAt set. Used as the
      * single-season entry point for permanent purges (currently exercised directly by

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -74,6 +74,32 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         });
     }
 
+    /** Every user, with $seasons already initialized so the admin overview's per-user season
+     * count doesn't trigger a lazy-loading query per row.
+     *
+     * @return list<User>
+     */
+    public function findAllForAdminOverview(): array
+    {
+        /** @var list<User> $users */
+        $users = $this->createQueryBuilder('u')
+            ->orderBy('u.email', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        if ([] === $users) {
+            return [];
+        }
+
+        $this->createQueryBuilder('u')
+            ->select('partial u.{id}', 's')
+            ->leftJoin('u.seasons', 's')
+            ->getQuery()
+            ->getResult();
+
+        return $users;
+    }
+
     public function makeAdmin(string $email): void
     {
         $user = $this->findOneBy(['email' => $email]);

--- a/src/Security/ResetPasswordMailer.php
+++ b/src/Security/ResetPasswordMailer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Security;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+use Tvdt\Entity\User;
+use Tvdt\Repository\UserRepository;
+
+/** Shared by the self-service reset-password request flow and the admin-triggered one, so the
+ * token-generation + email-sending logic exists in exactly one place. */
+readonly class ResetPasswordMailer
+{
+    public function __construct(
+        private ResetPasswordHelperInterface $resetPasswordHelper,
+        private UserRepository $userRepository,
+        private MailerInterface $mailer,
+        private TranslatorInterface $translator,
+        private LoggerInterface $logger,
+    ) {}
+
+    /** Generates a reset token and emails it to $user. Returns null (after invalidating the
+     * freshly generated token, and logging) on a mail transport failure, so a stray token isn't
+     * left usable when its email never actually arrived.
+     *
+     * @throws ResetPasswordExceptionInterface
+     */
+    public function send(User $user): ?ResetPasswordToken
+    {
+        $resetToken = $this->resetPasswordHelper->generateResetToken($user);
+
+        $email = new TemplatedEmail()
+            ->to($user->getUserIdentifier())
+            ->subject($this->translator->trans('Your password reset request'))
+            ->htmlTemplate('reset_password/email.html.twig')
+            ->context(['resetToken' => $resetToken]);
+
+        try {
+            $this->mailer->send($email);
+        } catch (TransportExceptionInterface $transportException) {
+            $this->logger->error($transportException->getMessage());
+            $this->userRepository->invalidateResetPasswordRequests($user);
+
+            return null;
+        }
+
+        return $resetToken;
+    }
+}

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -1,0 +1,34 @@
+{% extends 'molshoop/base.html.twig' %}
+
+{% import 'molshoop/partials/breadcrumb.html.twig' as breadcrumb %}
+
+{% block title %}{{ parent() }}{{ 'Admin'|trans }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ breadcrumb.breadcrumb([
+        {label: 'Home'|trans, path: path('tvdt_molshoop_index')},
+        {label: 'Admin'|trans},
+    ]) }}
+{% endblock %}
+
+{% block body %}
+    {% set tabs = [
+        {id: 'users', label: 'Users'|trans, route: 'tvdt_admin_users'},
+        {id: 'seasons', label: 'Seasons'|trans, route: 'tvdt_admin_seasons'},
+    ] %}
+
+    <h2 class="mb-3">{{ 'Admin'|trans }}</h2>
+
+    <ul class="nav nav-tabs mb-3">
+        {% for tab in tabs %}
+            <li class="nav-item">
+                <a class="nav-link{{ activeTab == tab.id ? ' active' }}" href="{{ path(tab.route) }}">
+                    {{ tab.label }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+    <div class="pt-3">
+        {{ include(template) }}
+    </div>
+{% endblock body %}

--- a/templates/admin/tab_seasons.html.twig
+++ b/templates/admin/tab_seasons.html.twig
@@ -1,0 +1,34 @@
+<div class="table-responsive">
+    <table class="table table-striped align-middle">
+        <thead>
+            <tr>
+                <th>{{ 'Name'|trans }}</th>
+                <th>{{ 'Code'|trans }}</th>
+                <th>{{ 'Owners'|trans }}</th>
+                <th>{{ 'Active'|trans }}</th>
+                <th>{{ 'Active Quiz'|trans }}</th>
+                <th>{{ 'Quizzes'|trans }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for season in seasons %}
+                <tr>
+                    <td>
+                        <a href="{{ path('tvdt_molshoop_season', {seasonCode: season.seasonCode}) }}">{{ season.name }}</a>
+                    </td>
+                    <td>{{ season.seasonCode }}</td>
+                    <td>{{ season.owners|map(o => o.email)|join(', ') }}</td>
+                    <td>
+                        {% if season.activeQuiz %}
+                            <span class="badge text-bg-success">{{ 'Active'|trans }}</span>
+                        {% else %}
+                            <span class="badge text-bg-secondary">{{ 'Not active'|trans }}</span>
+                        {% endif %}
+                    </td>
+                    <td>{{ season.activeQuiz ? season.activeQuiz.name : 'No active quiz'|trans }}</td>
+                    <td>{{ season.quizzes|length }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/templates/admin/tab_users.html.twig
+++ b/templates/admin/tab_users.html.twig
@@ -1,0 +1,99 @@
+<div class="table-responsive">
+    <table class="table table-striped align-middle">
+        <thead>
+            <tr>
+                <th>{{ 'Email'|trans }}</th>
+                <th>{{ 'Confirmed'|trans }}</th>
+                <th>{{ 'Registered'|trans }}</th>
+                <th>{{ 'Last activity'|trans }}</th>
+                <th>{{ 'Seasons'|trans }}</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for user in users %}
+                <tr>
+                    <td>{{ user.email }}</td>
+                    <td>
+                        {% if user.isVerified %}
+                            <i class="bi bi-check-lg text-success" aria-label="{{ 'Confirmed'|trans }}"></i>
+                        {% else %}
+                            <i class="bi bi-x-lg text-danger" aria-label="{{ 'Not confirmed'|trans }}"></i>
+                        {% endif %}
+                    </td>
+                    <td>{{ user.created|date('d-m-Y') }}</td>
+                    <td>{{ user.lastActivity ? user.lastActivity|date('d-m-Y H:i') : 'Never'|trans }}</td>
+                    <td>{{ user.seasons|length }}</td>
+                    <td class="text-end text-nowrap">
+                        <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal"
+                                data-bs-target="#resetPassword-{{ user.id }}">{{ 'Send password reset email'|trans }}</button>
+                        {% if user.id != app.user.id %}
+                            <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal"
+                                    data-bs-target="#deleteUser-{{ user.id }}">{{ 'Delete'|trans }}</button>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% for user in users %}
+    <div class="modal fade" id="resetPassword-{{ user.id }}" data-bs-backdrop="static"
+         tabindex="-1" aria-labelledby="resetPassword-{{ user.id }}Label" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title fs-5" id="resetPassword-{{ user.id }}Label">{{ 'Please Confirm'|trans }}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body text-start">
+                    {{ 'Send a password reset email to {email}?'|trans({email: user.email}) }}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'No'|trans }}</button>
+                    <form action="{{ path('tvdt_admin_user_reset_password', {user: user.id}) }}" method="POST">
+                        <input type="hidden" name="_token" value="{{ csrf_token('admin_reset_password') }}">
+                        <button type="submit" class="btn btn-primary">{{ 'Yes'|trans }}</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if user.id != app.user.id %}
+        <div class="modal fade" id="deleteUser-{{ user.id }}" data-bs-backdrop="static"
+             data-controller="bo--modal bo--type-to-confirm" data-bo--modal-target="modal"
+             data-bo--type-to-confirm-words-value="{{ ['verwijderen', 'delete']|json_encode }}"
+             data-action="hidden.bs.modal->bo--modal#resetDirty"
+             tabindex="-1" aria-labelledby="deleteUser-{{ user.id }}Label" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <form action="{{ path('tvdt_admin_user_delete', {user: user.id}) }}" method="POST">
+                        <div class="modal-header">
+                            <h5 class="modal-title fs-5" id="deleteUser-{{ user.id }}Label">{{ 'Delete user'|trans }}</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body text-start">
+                            <p>{{ 'This permanently deletes {email} and every season they are the only owner of. There is no way to undo this.'|trans({email: user.email}) }}</p>
+                            <input type="hidden" name="_token" value="{{ csrf_token('admin_delete_user') }}">
+                            <label class="form-label" for="deleteUserConfirmation-{{ user.id }}">
+                                {{ 'Type delete to confirm'|trans }}
+                            </label>
+                            <input type="text" class="form-control" id="deleteUserConfirmation-{{ user.id }}" name="confirmation"
+                                   autocomplete="off"
+                                   data-bo--type-to-confirm-target="input"
+                                   data-action="input->bo--modal#markDirty change->bo--modal#markDirty input->bo--type-to-confirm#check">
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
+                            <button type="submit" class="btn btn-danger" disabled data-bo--type-to-confirm-target="submit">
+                                {{ 'Delete user'|trans }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endfor %}

--- a/templates/molshoop/index.html.twig
+++ b/templates/molshoop/index.html.twig
@@ -15,7 +15,7 @@
         <div class="col-md-8 col-12">
             <div class="d-flex flex-row align-items-center mb-3">
                 <h2 class="mb-0 pe-2">
-                    {{ is_granted('ROLE_ADMIN') ? 'All Seasons'|trans : 'Your Seasons'|trans }}
+                    {{ 'Your Seasons'|trans }}
                 </h2>
                 <a class="link" href="{{ path('tvdt_molshoop_season_add') }}">
                     {{ 'Add'|trans }}
@@ -28,12 +28,6 @@
                             <div>
                                 <a href="{{ path('tvdt_molshoop_season', {seasonCode: season.seasonCode}) }}"
                                    class="stretched-link text-reset text-decoration-none fw-semibold">{{ season.name }}</a>
-                                {% if is_granted('ROLE_ADMIN') %}
-                                    <div class="text-body-secondary small">
-                                        <strong>{{ t('{count, plural, one {Owner} other {Owners}}', {count: season.owners|length})|trans }}:</strong>
-                                        {{ season.owners|map(o => o.email)|join(', ') }}
-                                    </div>
-                                {% endif %}
                                 <div class="text-body-secondary small">
                                     <strong>{{ 'Active Quiz'|trans }}:</strong>
                                     {% if season.activeQuiz %}

--- a/templates/molshoop/nav.html.twig
+++ b/templates/molshoop/nav.html.twig
@@ -45,6 +45,12 @@
                         </div>
                     </div>
                 </li>
+                {% if is_granted('ROLE_ADMIN') %}
+                    <li class="nav-item">
+                        <a class="nav-link{% if app.current_route() starts with 'tvdt_admin_' %} active{% endif %}"
+                           href="{{ path('tvdt_admin_users') }}">{{ 'Admin'|trans }}</a>
+                    </li>
+                {% endif %}
                 {% if is_granted('IS_AUTHENTICATED') %}
                     <li class="nav-item">
                         <a class="nav-link{% if 'tvdt_molshoop_settings' == app.current_route() %} active{% endif %}"

--- a/tests/Integration/Controller/Admin/AdminControllerTest.php
+++ b/tests/Integration/Controller/Admin/AdminControllerTest.php
@@ -35,10 +35,30 @@ final class AdminControllerTest extends AbstractControllerWebTestCase
 
     public function testUsersTabListsUsersWithExpectedColumns(): void
     {
+        // test@example.org: unverified, owns no seasons, never had activity recorded.
         $crawler = $this->client->request(Request::METHOD_GET, '/admin');
 
         self::assertResponseIsSuccessful();
-        $this->assertStringContainsString('test@example.org', $crawler->filter('body')->text());
+
+        $row = $crawler->filter('table tbody tr')->reduce(
+            static fn ($node): bool => str_contains($node->text(), 'test@example.org'),
+        );
+        $this->assertGreaterThan(0, $row->count(), 'No table row found for test@example.org');
+
+        $cells = $row->filter('td')->each(static fn ($node): string => mb_trim($node->text()));
+
+        $this->assertSame('test@example.org', $cells[0]);
+        $this->assertSame('', $cells[1]); // confirmed column renders an icon, not text
+        $this->assertMatchesRegularExpression('/^\d{2}-\d{2}-\d{4}$/', $cells[2]); // registered date
+        $this->assertSame('Never', $cells[3]); // last activity
+        $this->assertSame('0', $cells[4]); // season count
+
+        $this->assertCount(
+            0,
+            $row->filter('i.bi-check-lg'),
+            'test@example.org is not email-verified, so the confirmed column must show the "not confirmed" icon',
+        );
+        $this->assertGreaterThan(0, $row->filter('i.bi-x-lg')->count());
     }
 
     public function testSeasonsTabListsAllSeasons(): void
@@ -176,6 +196,37 @@ final class AdminControllerTest extends AbstractControllerWebTestCase
         $this->entityManager->clear();
 
         $this->assertNotInstanceOf(User::class, $this->entityManager->getRepository(User::class)->find($userId));
+    }
+
+    public function testDeleteUserWithoutConfirmationKeepsUser(): void
+    {
+        $userId = $this->getUserByEmail('sole-owner@example.org')->id;
+        $token = $this->getCsrfTokenFromPage('/admin', \sprintf('%s/delete', $userId));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/admin/users/%s/delete', $userId), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/admin');
+        $this->entityManager->clear();
+
+        $this->assertInstanceOf(User::class, $this->entityManager->getRepository(User::class)->find($userId));
+    }
+
+    public function testDeleteUserWithWrongConfirmationKeepsUser(): void
+    {
+        $userId = $this->getUserByEmail('sole-owner@example.org')->id;
+        $token = $this->getCsrfTokenFromPage('/admin', \sprintf('%s/delete', $userId));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/admin/users/%s/delete', $userId), [
+            '_token' => $token,
+            'confirmation' => 'wrong',
+        ]);
+
+        self::assertResponseRedirects('/admin');
+        $this->entityManager->clear();
+
+        $this->assertInstanceOf(User::class, $this->entityManager->getRepository(User::class)->find($userId));
     }
 
     public function testAdminCannotDeleteTheirOwnAccountThroughThisRoute(): void

--- a/tests/Integration/Controller/Admin/AdminControllerTest.php
+++ b/tests/Integration/Controller/Admin/AdminControllerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Integration\Controller\Admin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\Request;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+use Tvdt\Controller\Admin\AdminController;
+use Tvdt\DataFixtures\TestFixtures;
+use Tvdt\Entity\User;
+use Tvdt\Tests\Integration\Controller\AbstractControllerWebTestCase;
+
+#[CoversClass(AdminController::class)]
+final class AdminControllerTest extends AbstractControllerWebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Molshoop pages resolve locale from the logged-in user's profile, not Accept-Language
+        // (see LocaleListener), so assertions on English flash text need the fixture user set to 'en'.
+        $admin = $this->getUserByEmail(TestFixtures::ADMIN_EMAIL);
+        $admin->locale = 'en';
+
+        $this->entityManager->flush();
+
+        $this->loginAs(TestFixtures::ADMIN_EMAIL);
+    }
+
+    public function testUsersTabListsUsersWithExpectedColumns(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('test@example.org', $crawler->filter('body')->text());
+    }
+
+    public function testSeasonsTabListsAllSeasons(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/seasons');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('Krtek', $crawler->filter('body')->text());
+        $this->assertStringContainsString('Doomed Season', $crawler->filter('body')->text());
+    }
+
+    public function testUsersTabIsDeniedForNonAdmin(): void
+    {
+        $this->loginAs('test@example.org');
+
+        $this->client->request(Request::METHOD_GET, '/admin');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testSeasonsTabIsDeniedForNonAdmin(): void
+    {
+        $this->loginAs('test@example.org');
+
+        $this->client->request(Request::METHOD_GET, '/admin/seasons');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testResetPasswordSendsExactlyOneEmailAndFlashesSuccess(): void
+    {
+        $user = $this->getUserByEmail('test@example.org');
+        $token = $this->getCsrfTokenFromPage('/admin', \sprintf('%s/reset-password', $user->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/admin/users/%s/reset-password', $user->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/admin');
+        self::assertEmailCount(1);
+
+        $this->client->followRedirect();
+        $this->assertStringContainsString('A password reset email has been sent to this user.', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testResetPasswordBypassesTheUsersOwnThrottle(): void
+    {
+        $user = $this->getUserByEmail('test@example.org');
+
+        // Simulate the user having just hit the self-service form's throttle themselves.
+        self::getContainer()->get(ResetPasswordHelperInterface::class)->generateResetToken($user);
+
+        $token = $this->getCsrfTokenFromPage('/admin', \sprintf('%s/reset-password', $user->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/admin/users/%s/reset-password', $user->id), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/admin');
+        self::assertEmailCount(1);
+
+        $this->client->followRedirect();
+        $this->assertStringContainsString('A password reset email has been sent to this user.', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testDeleteUserRemovesTheUserAndFlashesSuccess(): void
+    {
+        $userId = $this->getUserByEmail('sole-owner@example.org')->id;
+        $token = $this->getCsrfTokenFromPage('/admin', \sprintf('%s/delete', $userId));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/admin/users/%s/delete', $userId), [
+            '_token' => $token,
+            'confirmation' => 'delete',
+        ]);
+
+        self::assertResponseRedirects('/admin');
+        $this->entityManager->clear();
+
+        $this->assertNotInstanceOf(User::class, $this->entityManager->getRepository(User::class)->find($userId));
+    }
+
+    public function testAdminCannotDeleteTheirOwnAccountThroughThisRoute(): void
+    {
+        $admin = $this->getUserByEmail(TestFixtures::ADMIN_EMAIL);
+
+        // The delete button/modal for the admin's own row is intentionally not rendered (see
+        // admin/tab_users.html.twig), so a valid token is scraped from another user's delete form —
+        // the CSRF token id is the same for every row — to verify the controller-side guard directly.
+        $other = $this->getUserByEmail('test@example.org');
+        $token = $this->getCsrfTokenFromPage('/admin', \sprintf('%s/delete', $other->id));
+
+        $this->client->request(Request::METHOD_POST, \sprintf('/admin/users/%s/delete', $admin->id), [
+            '_token' => $token,
+            'confirmation' => 'delete',
+        ]);
+
+        self::assertResponseRedirects('/admin');
+        $this->entityManager->clear();
+
+        $this->assertInstanceOf(User::class, $this->entityManager->getRepository(User::class)->find($admin->id));
+    }
+}

--- a/tests/Integration/Controller/Admin/AdminControllerTest.php
+++ b/tests/Integration/Controller/Admin/AdminControllerTest.php
@@ -6,6 +6,7 @@ namespace Tvdt\Tests\Integration\Controller\Admin;
 
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
@@ -63,11 +64,37 @@ final class AdminControllerTest extends AbstractControllerWebTestCase
 
     public function testSeasonsTabListsAllSeasons(): void
     {
+        // Krtek Weekend: owned by krtek-admin@example.org and user2@example.org, active (Quiz 1
+        // of 9). Doomed Season: sole-owner@example.org's only season, no active quiz.
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/seasons');
 
         self::assertResponseIsSuccessful();
-        $this->assertStringContainsString('Krtek', $crawler->filter('body')->text());
-        $this->assertStringContainsString('Doomed Season', $crawler->filter('body')->text());
+
+        $krtekCells = $this->seasonRowCells($crawler, 'Krtek Weekend');
+        $this->assertSame('krtek', $krtekCells[1]);
+        $this->assertStringContainsString('krtek-admin@example.org', $krtekCells[2]);
+        $this->assertStringContainsString('user2@example.org', $krtekCells[2]);
+        $this->assertSame('Active', $krtekCells[3]);
+        $this->assertSame('Quiz 1', $krtekCells[4]);
+        $this->assertSame('9', $krtekCells[5]);
+
+        $doomedCells = $this->seasonRowCells($crawler, 'Doomed Season');
+        $this->assertSame('doomd', $doomedCells[1]);
+        $this->assertSame('sole-owner@example.org', $doomedCells[2]);
+        $this->assertSame('Not active', $doomedCells[3]);
+        $this->assertSame('No active quiz', $doomedCells[4]);
+        $this->assertSame('1', $doomedCells[5]);
+    }
+
+    /** @return list<string> */
+    private function seasonRowCells(Crawler $crawler, string $seasonName): array
+    {
+        $row = $crawler->filter('table tbody tr')->reduce(
+            static fn ($node): bool => str_contains($node->text(), $seasonName),
+        );
+        $this->assertGreaterThan(0, $row->count(), \sprintf('No table row found for %s', $seasonName));
+
+        return $row->filter('td')->each(static fn ($node): string => mb_trim($node->text()));
     }
 
     public function testUsersTabQueryCountDoesNotGrowWithMoreUsers(): void

--- a/tests/Integration/Controller/Admin/AdminControllerTest.php
+++ b/tests/Integration/Controller/Admin/AdminControllerTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Tvdt\Tests\Integration\Controller\Admin;
 
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Profiler\Profile;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 use Tvdt\Controller\Admin\AdminController;
 use Tvdt\DataFixtures\TestFixtures;
+use Tvdt\Entity\Quiz;
+use Tvdt\Entity\Season;
 use Tvdt\Entity\User;
 use Tvdt\Tests\Integration\Controller\AbstractControllerWebTestCase;
 
@@ -46,6 +50,32 @@ final class AdminControllerTest extends AbstractControllerWebTestCase
         $this->assertStringContainsString('Doomed Season', $crawler->filter('body')->text());
     }
 
+    public function testUsersTabQueryCountDoesNotGrowWithMoreUsers(): void
+    {
+        // A throwaway request first, so the assertion below isn't polluted by setUp()'s own writes.
+        $this->client->request(Request::METHOD_GET, '/admin');
+
+        for ($i = 0; $i < 20; ++$i) {
+            $user = new User();
+            $user->email = \sprintf('extra-user-%d@example.org', $i);
+            $user->password = 'irrelevant';
+            $user->addSeason($this->getSeasonByCode('krtek'));
+
+            $this->entityManager->persist($user);
+        }
+
+        $this->entityManager->flush();
+
+        $this->client->enableProfiler();
+        $this->client->request(Request::METHOD_GET, '/admin');
+
+        self::assertResponseIsSuccessful();
+        // A flat query count regardless of row count: one query to list users, one to hydrate
+        // every user's $seasons collection, plus the auth reload for the logged-in admin. If this
+        // creeps up, something reintroduced a per-row lazy load (N+1).
+        $this->assertLessThanOrEqual(5, $this->getQueryCount(), 'Adding more users should not add more queries (N+1 on the per-user season count).');
+    }
+
     public function testUsersTabIsDeniedForNonAdmin(): void
     {
         $this->loginAs('test@example.org');
@@ -53,6 +83,38 @@ final class AdminControllerTest extends AbstractControllerWebTestCase
         $this->client->request(Request::METHOD_GET, '/admin');
 
         self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testSeasonsTabQueryCountDoesNotGrowWithMoreSeasons(): void
+    {
+        // A throwaway request first, so the assertion below isn't polluted by setUp()'s own writes.
+        $this->client->request(Request::METHOD_GET, '/admin/seasons');
+
+        $owner = $this->getUserByEmail('test@example.org');
+        for ($i = 0; $i < 20; ++$i) {
+            $season = new Season();
+            $season->name = \sprintf('Extra Season %d', $i);
+            $season->seasonCode = \sprintf('sn%03d', $i);
+            $season->addOwner($owner);
+
+            $quiz = new Quiz();
+            $quiz->name = 'Extra Quiz';
+            $season->addQuiz($quiz);
+            $season->activeQuiz = $quiz;
+
+            $this->entityManager->persist($season);
+        }
+
+        $this->entityManager->flush();
+
+        $this->client->enableProfiler();
+        $this->client->request(Request::METHOD_GET, '/admin/seasons');
+
+        self::assertResponseIsSuccessful();
+        // A flat query count regardless of row count: one query for the seasons + activeQuiz,
+        // one to hydrate owners, one to hydrate quizzes, plus the auth reload for the logged-in
+        // admin. If this creeps up, something reintroduced a per-row lazy load (N+1).
+        $this->assertLessThanOrEqual(5, $this->getQueryCount(), 'Adding more seasons should not add more queries (N+1 on owners/quizzes/activeQuiz).');
     }
 
     public function testSeasonsTabIsDeniedForNonAdmin(): void
@@ -135,5 +197,17 @@ final class AdminControllerTest extends AbstractControllerWebTestCase
         $this->entityManager->clear();
 
         $this->assertInstanceOf(User::class, $this->entityManager->getRepository(User::class)->find($admin->id));
+    }
+
+    private function getQueryCount(): int
+    {
+        $profile = $this->client->getProfile();
+        $this->assertNotFalse($profile);
+        $this->assertInstanceOf(Profile::class, $profile);
+
+        $collector = $profile->getCollector('db');
+        $this->assertInstanceOf(DoctrineDataCollector::class, $collector);
+
+        return $collector->getQueryCount();
     }
 }

--- a/tests/Integration/Controller/Molshoop/MolshoopControllerTest.php
+++ b/tests/Integration/Controller/Molshoop/MolshoopControllerTest.php
@@ -7,12 +7,32 @@ namespace Tvdt\Tests\Integration\Controller\Molshoop;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\HttpFoundation\Request;
 use Tvdt\Controller\Molshoop\MolshoopController;
+use Tvdt\DataFixtures\TestFixtures;
 use Tvdt\Entity\Season;
 use Tvdt\Tests\Integration\Controller\AbstractControllerWebTestCase;
 
 #[CoversClass(MolshoopController::class)]
 final class MolshoopControllerTest extends AbstractControllerWebTestCase
 {
+    /** An admin owns no seasons in the fixtures, so the homepage must show only their own (none) —
+     * never every season in the system, which is now exclusively the Admin > Seasons tab's job. */
+    public function testHomepageShowsOnlyTheAdminsOwnSeasonsNotEverySeason(): void
+    {
+        $admin = $this->getUserByEmail(TestFixtures::ADMIN_EMAIL);
+        // Molshoop pages resolve locale from the user's profile, not Accept-Language (see LocaleListener).
+        $admin->locale = 'en';
+
+        $this->entityManager->flush();
+
+        $this->client->loginUser($admin);
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/molshoop/');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('You have no seasons yet.', $crawler->filter('body')->text());
+        $this->assertStringNotContainsString('Doomed Season', (string) $this->client->getResponse()->getContent());
+    }
+
     public function testAddSeasonCopiesOwnersLocaleIntoSettings(): void
     {
         $user = $this->getUserByEmail('user2@example.org');

--- a/tests/Unit/EventListener/LastActivityListenerTest.php
+++ b/tests/Unit/EventListener/LastActivityListenerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Unit\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Safe\DateTimeImmutable;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Tvdt\Entity\User;
+use Tvdt\EventListener\LastActivityListener;
+
+#[CoversClass(LastActivityListener::class)]
+final class LastActivityListenerTest extends TestCase
+{
+    public function testDoesNothingForAnAnonymousRequest(): void
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        new LastActivityListener($security, $em)->onKernelController($this->createEvent());
+    }
+
+    public function testDoesNothingForASubRequest(): void
+    {
+        $user = new User();
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        new LastActivityListener($security, $em)->onKernelController($this->createEvent(HttpKernelInterface::SUB_REQUEST));
+
+        $this->assertNotInstanceOf(\DateTimeImmutable::class, $user->lastActivity);
+    }
+
+    public function testSetsLastActivityAndFlushesWhenNeverRecordedBefore(): void
+    {
+        $user = new User();
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        new LastActivityListener($security, $em)->onKernelController($this->createEvent());
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $user->lastActivity);
+    }
+
+    public function testDoesNotFlushAgainWithinTheThrottleWindow(): void
+    {
+        $user = new User();
+        $recent = new DateTimeImmutable('-30 seconds');
+        $user->lastActivity = $recent;
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        new LastActivityListener($security, $em)->onKernelController($this->createEvent());
+
+        $this->assertSame($recent, $user->lastActivity);
+    }
+
+    public function testFlushesAgainOnceTheThrottleWindowHasPassed(): void
+    {
+        $user = new User();
+        $stale = new DateTimeImmutable('-90 seconds');
+        $user->lastActivity = $stale;
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        new LastActivityListener($security, $em)->onKernelController($this->createEvent());
+
+        $this->assertNotSame($stale, $user->lastActivity);
+    }
+
+    private function createEvent(int $requestType = HttpKernelInterface::MAIN_REQUEST): ControllerEvent
+    {
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        return new ControllerEvent($kernel, static fn (): \stdClass => new \stdClass(), Request::create('/'), $requestType);
+    }
+}

--- a/tests/Unit/Rector/Fixture/no_change_non_safe.php.inc
+++ b/tests/Unit/Rector/Fixture/no_change_non_safe.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+class SomeClass
+{
+    public ?\DateTimeImmutable $expiresAt;
+
+    public function setDate(\DateTimeImmutable $date): void
+    {
+        if ($date instanceof \DateTimeImmutable) {
+            echo 'yes';
+        }
+    }
+
+    public function create(): \DateTimeImmutable
+    {
+        return new \Safe\DateTimeImmutable();
+    }
+}

--- a/tests/Unit/Rector/Fixture/no_safe_namespace_type_hint.php.inc
+++ b/tests/Unit/Rector/Fixture/no_safe_namespace_type_hint.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+class SomeClass
+{
+    public ?\Safe\DateTimeImmutable $expiresAt;
+
+    private \Safe\DateTimeImmutable|\Safe\DateTime $either;
+
+    public function setDate(\Safe\DateTimeImmutable $date): void
+    {
+    }
+
+    public function checkInstanceof(\Safe\DateTimeImmutable $date): void
+    {
+        if ($date instanceof \Safe\DateTimeImmutable) {
+            echo 'yes';
+        }
+
+        is_a($date, \Safe\DateTimeImmutable::class);
+
+        is_subclass_of($date, \Safe\DateTimeImmutable::class);
+
+        is_a($date, '\Safe\DateTimeImmutable');
+    }
+}
+
+-----
+<?php
+
+class SomeClass
+{
+    public ?\DateTimeImmutable $expiresAt;
+
+    private \DateTimeImmutable|\DateTime $either;
+
+    public function setDate(\DateTimeImmutable $date): void
+    {
+    }
+
+    public function checkInstanceof(\DateTimeImmutable $date): void
+    {
+        if ($date instanceof \DateTimeImmutable) {
+            echo 'yes';
+        }
+
+        is_a($date, \DateTimeImmutable::class);
+
+        is_subclass_of($date, \DateTimeImmutable::class);
+
+        is_a($date, '\DateTimeImmutable');
+    }
+}

--- a/tests/Unit/Rector/Fixture/use_import.php.inc
+++ b/tests/Unit/Rector/Fixture/use_import.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+use Safe\DateTime;
+use Safe\DateTimeImmutable;
+
+class SomeClass
+{
+    public ?DateTimeImmutable $expiresAt;
+
+    private DateTimeImmutable|DateTime $either;
+
+    public function setDate(DateTimeImmutable $date): void
+    {
+    }
+
+    public function checkInstanceof(DateTimeImmutable $date): void
+    {
+        if ($date instanceof DateTimeImmutable) {
+            echo 'yes';
+        }
+
+        is_a($date, DateTimeImmutable::class);
+    }
+}
+
+-----
+<?php
+
+use Safe\DateTime;
+use Safe\DateTimeImmutable;
+
+class SomeClass
+{
+    public ?\DateTimeImmutable $expiresAt;
+
+    private \DateTimeImmutable|\DateTime $either;
+
+    public function setDate(\DateTimeImmutable $date): void
+    {
+    }
+
+    public function checkInstanceof(\DateTimeImmutable $date): void
+    {
+        if ($date instanceof \DateTimeImmutable) {
+            echo 'yes';
+        }
+
+        is_a($date, \DateTimeImmutable::class);
+    }
+}

--- a/tests/Unit/Rector/NoSafeNamespaceTypeHintRectorTest.php
+++ b/tests/Unit/Rector/NoSafeNamespaceTypeHintRectorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Unit\Rector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Tvdt\Rector\NoSafeNamespaceTypeHintRector;
+
+final class NoSafeNamespaceTypeHintRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        yield from self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/no_safe_namespace_type_hint.php';
+    }
+
+    public function testRuleDefinition(): void
+    {
+        $ruleDefinition = $this->make(NoSafeNamespaceTypeHintRector::class)->getRuleDefinition();
+
+        $this->assertSame(
+            'Replace Safe\\ namespace type hints with their parent class to avoid rejecting compatible non-Safe objects',
+            $ruleDefinition->getDescription(),
+        );
+        $this->assertCount(1, $ruleDefinition->getCodeSamples());
+    }
+}

--- a/tests/Unit/Rector/config/no_safe_namespace_type_hint.php
+++ b/tests/Unit/Rector/config/no_safe_namespace_type_hint.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Tvdt\Rector\NoSafeNamespaceTypeHintRector;
+
+return RectorConfig::configure()
+    ->withRules([NoSafeNamespaceTypeHintRector::class]);

--- a/tests/Unit/Security/ResetPasswordMailerTest.php
+++ b/tests/Unit/Security/ResetPasswordMailerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvdt\Tests\Unit\Security;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Safe\DateTimeImmutable;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+use Tvdt\Entity\User;
+use Tvdt\Repository\UserRepository;
+use Tvdt\Security\ResetPasswordMailer;
+
+#[CoversClass(ResetPasswordMailer::class)]
+final class ResetPasswordMailerTest extends TestCase
+{
+    public function testReturnsTheTokenOnSuccess(): void
+    {
+        $user = new User();
+        $user->email = 'test@example.org';
+
+        $token = new ResetPasswordToken('token', new DateTimeImmutable('+1 hour'), time());
+
+        $resetPasswordHelper = $this->createStub(ResetPasswordHelperInterface::class);
+        $resetPasswordHelper->method('generateResetToken')->willReturn($token);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())->method('send');
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->expects($this->never())->method('invalidateResetPasswordRequests');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $result = new ResetPasswordMailer($resetPasswordHelper, $userRepository, $mailer, $this->translator(), $logger)->send($user);
+
+        $this->assertSame($token, $result);
+    }
+
+    public function testInvalidatesTheFreshTokenAndReturnsNullOnTransportFailure(): void
+    {
+        $user = new User();
+        $user->email = 'test@example.org';
+
+        $token = new ResetPasswordToken('token', new DateTimeImmutable('+1 hour'), time());
+
+        $resetPasswordHelper = $this->createStub(ResetPasswordHelperInterface::class);
+        $resetPasswordHelper->method('generateResetToken')->willReturn($token);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())->method('send')->willThrowException(new TransportException('boom'));
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->expects($this->once())->method('invalidateResetPasswordRequests')->with($user);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $result = new ResetPasswordMailer($resetPasswordHelper, $userRepository, $mailer, $this->translator(), $logger)->send($user);
+
+        $this->assertNotInstanceOf(ResetPasswordToken::class, $result);
+    }
+
+    private function translator(): TranslatorInterface
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        return $translator;
+    }
+}

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -1,6 +1,7 @@
 'A candidate with this name already exists in this season': 'Er bestaat al een kandidaat met deze naam in dit seizoen'
 'A label with a similar name already exists': 'Er bestaat al een label met deze naam'
 'A new confirmation email has been sent. Please check your inbox.': 'Er is een nieuwe bevestigingsmail verstuurd. Check je inbox.'
+'A password reset email has been sent to this user.': 'Er is een wachtwoordherstel-e-mail naar deze gebruiker gestuurd.'
 'A quiz with this name already exists in this season': 'Er bestaat al een test met deze naam in dit seizoen'
 Actions: Acties
 Activate: Activeren
@@ -18,6 +19,7 @@ Add: Toevoegen
 'Add label': 'Label toevoegen'
 'Add owner': 'Eigenaar toevoegen'
 'Add question': 'Vraag toevoegen'
+Admin: Admin
 'After changing your email address you will receive a new confirmation email.': 'Na het wijzigen van je e-mailadres ontvang je een nieuwe bevestigingsmail.'
 All: Alle
 'All Seasons': 'Alle seizoenen'
@@ -51,6 +53,7 @@ Candidates: Kandidaten
 'Check your email': 'Controleer je e-mail'
 'Clear Quiz...': 'Test leegmaken...'
 Close: Sluiten
+Code: Code
 Colour: Kleur
 Completed: Voltooid
 Concept: Concept
@@ -66,6 +69,7 @@ Corrections: Jokers
 'Could not find candidate with name {name}': 'Kon kandidaat met naam {name} niet vinden'
 'Could not find candidate with name {name} in elimination.': 'Kon geen kandidaat vinden met de naam {name} in de eliminatie'
 'Could not load releases from GitHub.': 'Kan releases niet laden van GitHub.'
+'Could not send a password reset email to this user.': 'Het is niet gelukt om een wachtwoordherstel-e-mail naar deze gebruiker te sturen.'
 Create: Aanmaken
 'Create a season': 'Maak een seizoen aan'
 'Create an account': 'Maak een account aan'
@@ -86,6 +90,7 @@ Delete: Verwijderen
 'Delete account...': 'Account verwijderen...'
 'Delete season': 'Seizoen verwijderen'
 'Delete season...': 'Seizoen verwijderen...'
+'Delete user': 'Gebruiker verwijderen'
 Delete...: Verwijderen...
 'Deleting this season hides it, its tests, and all candidate answers everywhere. There is no way to undo this yourself yet.': 'Als je dit seizoen verwijdert, wordt het overal verborgen, samen met de tests en antwoorden van kandidaten. Je kunt dit nog niet zelf ongedaan maken.'
 'Deleting your account also deletes every season you are the only owner of. This cannot be undone.': 'Als je je account verwijdert, worden ook alle seizoenen verwijderd waarvan jij de enige eigenaar bent. Dit kan niet ongedaan worden gemaakt.'
@@ -133,6 +138,7 @@ Inactive: Inactief
 Labels: Labels
 Language: Taal
 'Language saved': 'Taal opgeslagen'
+'Last activity': 'Laatste activiteit'
 'Leave season': 'Seizoen verlaten'
 'Leaving this season removes your ownership. You need at least one other owner before you can leave.': 'Als je dit seizoen verlaat, ben je geen eigenaar meer. Er moet minimaal één andere eigenaar zijn voordat je kunt vertrekken.'
 Light: Licht
@@ -146,6 +152,7 @@ Logout: Uitloggen
 Manage: Beheren
 Molehill: Molshoop
 Name: Naam
+Never: Nooit
 New: Nieuw
 'New email address': 'Nieuw e-mailadres'
 'New label': 'Nieuw label'
@@ -160,6 +167,7 @@ Next: Volgende
 'No results': 'Geen resultaten'
 'No user found with this email address': 'Geen gebruiker gevonden met dit e-mailadres'
 'Not Started': 'Niet gestart'
+'Not active': 'Niet actief'
 'Not confirmed': 'Niet bevestigd'
 'Number of dropouts:': 'Aantal afvallers:'
 'One candidate per line': 'Eén kandidaat per regel'
@@ -215,6 +223,7 @@ Red: Rood
 'Regenerate season code': 'Seizoenscode opnieuw genereren'
 'Regenerate season code...': 'Seizoenscode opnieuw genereren...'
 Register: Registreren
+Registered: Geregistreerd
 Releases: Releases
 'Remember me': 'Onthoud mij'
 Remove: Verwijderen
@@ -245,6 +254,7 @@ Season: Seizoen
 'Season deleted': 'Seizoen verwijderd'
 'Season renamed': 'Seizoen hernoemd'
 Seasons: Seizoenen
+'Send a password reset email to {email}?': 'Wachtwoordherstel-e-mail sturen naar {email}?'
 'Send password reset email': 'Stuur reset-e-mail'
 Settings: Instellingen
 'Show Numbers': 'Toon nummers'
@@ -276,6 +286,7 @@ Theme: Thema
 'This hides this season, its tests, and all candidate answers everywhere. There is no way to undo this yourself yet.': 'Dit verbergt dit seizoen overal, samen met de tests en antwoorden van kandidaten. Je kunt dit nog niet zelf ongedaan maken.'
 'This invalidates the current season code. Anyone using the old code will no longer be able to join this season.': 'Hiermee wordt de huidige seizoenscode ongeldig. Iedereen die de oude code gebruikt, kan dit seizoen niet meer vinden.'
 'This link will expire in {count}.': 'Deze link verloopt over {count}.'
+'This permanently deletes {email} and every season they are the only owner of. There is no way to undo this.': 'Dit verwijdert {email} definitief, samen met elk seizoen waarvan deze gebruiker de enige eigenaar is. Dit kan niet ongedaan worden gemaakt.'
 'This question cannot be deleted because it is used in a locked or active quiz': 'Deze vraag kan niet verwijderd worden omdat die gebruik wordt in een vergrendelde of actieve test'
 'This question has already been used': 'Deze vraag is al gebruikt'
 'This question has been used in a quiz. The copy in the quiz will not be affected.': 'Deze vraag is gebruikt in een test. De kopie in de test blijft ongewijzigd.'
@@ -290,7 +301,10 @@ Time: Tijd
 'Type delete to confirm': 'Typ verwijderen om te bevestigen'
 Unassign: Ontkoppelen
 'Undo finalization': 'Afronden ongedaan maken'
+'Use Settings to delete your own account.': 'Gebruik Instellingen om je eigen account te verwijderen.'
 'Used in': 'Gebruikt in'
+'User deleted': 'Gebruiker verwijderd'
+Users: Gebruikers
 View: Bekijken
 'View on GitHub': 'Bekijk op GitHub'
 White: Wit


### PR DESCRIPTION
## Summary
- New `ROLE_ADMIN`-gated `/admin` panel with two tabs:
  - **Users**: email confirmed, registered date, last activity, season count, plus "send password reset email" (bypasses the user's own request throttle) and delete-user (type-to-confirm) actions.
  - **Seasons**: name, code, owners, active/not-active status, active quiz, quiz count — this is now the only place every season in the system is listed.
- Admin nav button, visible only to `ROLE_ADMIN`.
- Homepage behavior change: admins now see only their own seasons on `/molshoop/`, same as regular users — the previous "admins see every season" behavior moved entirely into the new Admin → Seasons tab.
- `User::$created` (registration date, via Gedmo Timestampable) and `User::$lastActivity` (updated on every authenticated request, throttled to once per minute per user — chosen over login-only tracking since remember-me sessions last a week).

Closes #260

## Test plan
- [x] `just phpstan` — no errors
- [x] `just fix-cs` / twig-cs-fixer — clean
- [x] `just rector --dry-run` — clean
- [x] `just translations` — idempotent, all new strings translated to Dutch
- [x] `just test` — full suite passes (412 tests), including new `AdminControllerTest` (tab rendering, 403 for non-admins, reset-password email + throttle bypass, delete-user + self-delete guard) and a `LastActivityListener` unit test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Admin area for managing users and seasons, including admin-triggered password resets and protected account deletion.
* **Bug Fixes**
  * Season visibility now consistently matches the signed-in user, and the seasons heading is standardised.
* **Enhancements**
  * Introduced user registration time and “last activity”, updating automatically during main page requests.
* **Documentation**
  * Added guidance on avoiding N+1 query issues.
* **Tests**
  * Expanded admin and listener test coverage, including query-count regression checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->