### PR TITLE
Suppress noisy Turbo fetch-abort errors in Sentry

### DIFF
--- a/assets/molshoop.ts
+++ b/assets/molshoop.ts
@@ -33,6 +33,9 @@ Sentry.init({
     dsn: effectiveDsn,
     tunnel: useSpotlight ? 'http://localhost:8969/stream' : undefined,
     integrations: [feedbackIntegration],
+    // Turbo aborts in-flight fetch() visits on navigation; Firefox reports
+    // that as this TypeError instead of an AbortError. Not an app bug.
+    ignoreErrors: ['NetworkError when attempting to fetch resource.'],
 });
 
 // autoInject is unreliable in Sentry v10 due to the setupOnce guard; mount manually.

--- a/src/Entity/Candidate.php
+++ b/src/Entity/Candidate.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Uid\Uuid;
-use Tvdt\Helpers\Base64;
 use Tvdt\Repository\CandidateRepository;
 
 #[ORM\Entity(repositoryClass: CandidateRepository::class)]
@@ -38,10 +37,6 @@ class Candidate
     #[ORM\OneToMany(targetEntity: QuizCandidate::class, mappedBy: 'candidate', orphanRemoval: true)]
     public private(set) Collection $quizData;
 
-    public string $nameHash {
-        get => Base64::base64UrlEncode($this->name);
-    }
-
     public function __construct(
         #[ORM\Column(length: 16)]
         public string $name,
@@ -49,20 +44,5 @@ class Candidate
         $this->answersOnCandidate = new ArrayCollection();
         $this->givenAnswers = new ArrayCollection();
         $this->quizData = new ArrayCollection();
-    }
-
-    public function addAnswersOnCandidate(Answer $answersOnCandidate): void
-    {
-        if (!$this->answersOnCandidate->contains($answersOnCandidate)) {
-            $this->answersOnCandidate->add($answersOnCandidate);
-            $answersOnCandidate->addCandidate($this);
-        }
-    }
-
-    public function removeAnswersOnCandidate(Answer $answersOnCandidate): void
-    {
-        if ($this->answersOnCandidate->removeElement($answersOnCandidate)) {
-            $answersOnCandidate->removeCandidate($this);
-        }
     }
 }

--- a/src/Enum/FlashType.php
+++ b/src/Enum/FlashType.php
@@ -7,18 +7,11 @@ namespace Tvdt\Enum;
 enum FlashType: string
 {
     case Primary = 'primary';
-
     case Secondary = 'secondary';
-
     case Success = 'success';
-
     case Danger = 'danger';
-
     case Warning = 'warning';
-
     case Info = 'info';
-
     case Light = 'light';
-
     case Dark = 'dark';
 }


### PR DESCRIPTION
## Summary
- Filters `NetworkError when attempting to fetch resource.` out via Sentry's `ignoreErrors` — Firefox reports Turbo's aborted in-flight `fetch()` visits (cancelled by a subsequent navigation) with this message instead of `AbortError`; it fired across unrelated routes (`/molshoop/`, `/backoffice/settings`, `/login`) with no first-party stacktrace, confirming it's noise, not an app bug. Fixes Sentry issue PHP-SYMFONY-3X.
- Drops unused `Candidate::$nameHash` and `add/removeAnswersOnCandidate()` helpers, and stray blank lines in `FlashType`.

## Test plan
- [x] Pre-commit hooks passed (Rector, PHP-CS-Fixer, PHPStan, Deno fmt/lint/check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from expected Firefox navigation errors by excluding a known network fetch error from error reporting.

* **Improvements**
  * Expanded available flash message styles, including success, danger, warning, information, secondary and light variants.
  * Removed obsolete candidate data and relationship-management interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->