### PR TITLE
Load Sentry via asset mapper on quiz pages

### DIFF
--- a/assets/molshoop.ts
+++ b/assets/molshoop.ts
@@ -5,18 +5,7 @@ import '@hotwired/turbo';
 import './stimulus.ts';
 import './bootstrap.ts';
 import * as Sentry from '@sentry/browser';
-
-const dsn = document.querySelector<HTMLMetaElement>('meta[name="sentry-dsn"]')
-    ?.content ?? '';
-const userEmail =
-    document.querySelector<HTMLMetaElement>('meta[name="user-email"]')
-        ?.content ?? '';
-
-// When no real DSN is configured, route to the local Spotlight sidecar so
-// nothing reaches Sentry. A syntactically valid DSN is still required for the
-// SDK to initialise; the tunnel option redirects all transport to Spotlight.
-const useSpotlight = !dsn;
-const effectiveDsn = dsn || 'https://0@o0.ingest.sentry.io/0';
+import { initSentry } from './sentry.ts';
 
 const feedbackIntegration = Sentry.feedbackIntegration({
     colorScheme: 'system',
@@ -29,18 +18,7 @@ const feedbackIntegration = Sentry.feedbackIntegration({
     submitButtonLabel: 'Send Feedback',
 });
 
-Sentry.init({
-    dsn: effectiveDsn,
-    tunnel: useSpotlight ? 'http://localhost:8969/stream' : undefined,
-    integrations: [feedbackIntegration],
-    // Turbo aborts in-flight fetch() visits on navigation; Firefox reports
-    // that as this TypeError instead of an AbortError. Not an app bug.
-    ignoreErrors: ['NetworkError when attempting to fetch resource.'],
-});
+initSentry([feedbackIntegration]);
 
 // autoInject is unreliable in Sentry v10 due to the setupOnce guard; mount manually.
 feedbackIntegration.createWidget();
-
-if (userEmail) {
-    Sentry.setUser({ email: userEmail });
-}

--- a/assets/quiz.ts
+++ b/assets/quiz.ts
@@ -2,3 +2,6 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './styles/quiz.scss';
 import './stimulus.ts';
 import './bootstrap.ts';
+import { initSentry } from './sentry.ts';
+
+initSentry();

--- a/assets/sentry.ts
+++ b/assets/sentry.ts
@@ -1,0 +1,33 @@
+import * as Sentry from '@sentry/browser';
+
+type Integrations = NonNullable<
+    Parameters<typeof Sentry.init>[0]
+>['integrations'];
+
+export function initSentry(integrations: Integrations = []): void {
+    const dsn =
+        document.querySelector<HTMLMetaElement>('meta[name="sentry-dsn"]')
+            ?.content ?? '';
+    const userEmail =
+        document.querySelector<HTMLMetaElement>('meta[name="user-email"]')
+            ?.content ?? '';
+
+    // When no real DSN is configured, route to the local Spotlight sidecar so
+    // nothing reaches Sentry. A syntactically valid DSN is still required for the
+    // SDK to initialise; the tunnel option redirects all transport to Spotlight.
+    const useSpotlight = !dsn;
+    const effectiveDsn = dsn || 'https://0@o0.ingest.sentry.io/0';
+
+    Sentry.init({
+        dsn: effectiveDsn,
+        tunnel: useSpotlight ? 'http://localhost:8969/stream' : undefined,
+        integrations,
+        // Turbo aborts in-flight fetch() visits on navigation; Firefox reports
+        // that as this TypeError instead of an AbortError. Not an app bug.
+        ignoreErrors: ['NetworkError when attempting to fetch resource.'],
+    });
+
+    if (userEmail) {
+        Sentry.setUser({ email: userEmail });
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,12 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% block sentry_loader %}
-    <script
-        src="https://js-de.sentry-cdn.com/30cf438bc708c97e6f45c127bed9af96.min.js"
-        crossorigin="anonymous"
-    ></script>
-    {% endblock %}
     <title>
         {% block title %}Tijd voor de test{% endblock title %}
     </title>

--- a/templates/molshoop/base.html.twig
+++ b/templates/molshoop/base.html.twig
@@ -1,6 +1,5 @@
 {% extends 'base.html.twig' %}
 {% block importmap %}{{ importmap('molshoop') }}{% endblock %}
-{% block sentry_loader %}{% endblock %}
 {% block head_extra %}
     <meta name="sentry-dsn" content="{{ sentry_dsn }}">
     <meta name="user-email" content="{{ app.user ? app.user.userIdentifier : '' }}">

--- a/templates/quiz/base.html.twig
+++ b/templates/quiz/base.html.twig
@@ -1,6 +1,9 @@
 {% extends 'base.html.twig' %}
 {% block title %}{{ parent() }} | {% endblock %}
-{% block head_extra %}<meta name="turbo-refresh-method" content="replace">{% endblock %}
+{% block head_extra %}
+    <meta name="turbo-refresh-method" content="replace">
+    <meta name="sentry-dsn" content="{{ sentry_dsn }}">
+{% endblock %}
 {% block importmap %}{{ importmap('quiz') }}{% endblock %}
 {% block nav %}{{ include('quiz/nav.html.twig') }}{% endblock %}
 {% block main %}


### PR DESCRIPTION
## Summary
- The quiz side still loaded Sentry through a raw `<script src="js-de.sentry-cdn.com/...">` tag in `base.html.twig`, unlike molshoop which already initialises Sentry through the asset mapper (`assets/molshoop.ts`).
- Extracts the shared init logic into `assets/sentry.ts` and wires it into `assets/quiz.ts` too, then drops the CDN loader script from `base.html.twig` entirely.

## Test plan
- [x] `just check-ts` (Deno fmt/lint/check) passes
- [x] `just fix-cs` (PHP-CS-Fixer, Twig-CS-Fixer) passes with no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved error reporting across quiz and feedback experiences.
  * Feedback widgets now load more reliably.
  * Network-related errors are handled more consistently.

* **Configuration**
  * Quiz pages now support configurable Sentry reporting through page metadata.
  * User email details can be associated with reported errors when available.

* **Bug Fixes**
  * Resolved issues with feedback widget initialisation and error-monitoring setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->