### PR TITLE
Translate Sentry feedback widget, sync its theme

### DIFF
--- a/assets/molshoop.ts
+++ b/assets/molshoop.ts
@@ -6,19 +6,41 @@ import './stimulus.ts';
 import './bootstrap.ts';
 import * as Sentry from '@sentry/browser';
 import { initSentry } from './sentry.ts';
+import { trans } from './translator.ts';
 
 const feedbackIntegration = Sentry.feedbackIntegration({
-    colorScheme: 'system',
     showName: false,
     showEmail: true,
     isEmailRequired: false,
     autoInject: false,
-    triggerLabel: 'Report feedback',
-    formTitle: 'Report Feedback',
-    submitButtonLabel: 'Send Feedback',
+    triggerLabel: trans('Report feedback'),
+    triggerAriaLabel: trans('Report feedback'),
+    formTitle: trans('Report feedback'),
+    submitButtonLabel: trans('Send feedback'),
+    cancelButtonLabel: trans('Cancel'),
+    confirmButtonLabel: trans('Confirm'),
+    addScreenshotButtonLabel: trans('Add a screenshot'),
+    removeScreenshotButtonLabel: trans('Remove screenshot'),
+    nameLabel: trans('Name'),
+    namePlaceholder: trans('Name'),
+    emailLabel: trans('Email'),
+    emailPlaceholder: trans('your.email@example.org'),
+    messageLabel: trans('Description'),
+    messagePlaceholder: trans("What's the bug? What did you expect?"),
+    isRequiredLabel: trans('(required)'),
+    successMessageText: trans('Thank you for your report!'),
 });
 
 initSentry([feedbackIntegration]);
 
 // autoInject is unreliable in Sentry v10 due to the setupOnce guard; mount manually.
 feedbackIntegration.createWidget();
+
+const syncFeedbackTheme = (): void => {
+    const theme = document.documentElement.getAttribute('data-bs-theme');
+    feedbackIntegration.setTheme(theme === 'dark' ? 'dark' : 'light');
+};
+syncFeedbackTheme();
+new MutationObserver(syncFeedbackTheme).observe(document.documentElement, {
+    attributeFilter: ['data-bs-theme'],
+});

--- a/assets/translator.ts
+++ b/assets/translator.ts
@@ -1,0 +1,9 @@
+import { createTranslator } from '@symfony/ux-translator';
+import { localeFallbacks, messages } from '../var/translations/index.js';
+
+const translator = createTranslator({
+    messages,
+    localeFallbacks: localeFallbacks as unknown as Record<string, string>,
+});
+
+export const { trans } = translator;

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "symfony/translation": "8.1.*",
         "symfony/twig-bundle": "8.1.*",
         "symfony/uid": "8.1.*",
+        "symfony/ux-translator": "^3.4",
         "symfony/ux-turbo": "^3.3",
         "symfony/validator": "8.1.*",
         "symfony/yaml": "8.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b943ad58cbeceabd707cbe85fd32111d",
+    "content-hash": "3d645e22a77540a7e2fa4e74c0d02555",
     "packages": [
         {
             "name": "composer/pcre",
@@ -8514,6 +8514,87 @@
                 }
             ],
             "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/ux-translator",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/ux-translator.git",
+                "reference": "411b360297fa6202d90fcf6ab6e62850d94db2af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/ux-translator/zipball/411b360297fa6202d90fcf6ab6e62850d94db2af",
+                "reference": "411b360297fa6202d90fcf6ab6e62850d94db2af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/string": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.1|^12.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/ux",
+                    "name": "symfony/ux"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Hugo Alliaume",
+                    "email": "hugo@alliau.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Exposes Symfony Translations directly to JavaScript.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "symfony-ux"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/ux-translator/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-27T05:38:40+00:00"
         },
         {
             "name": "symfony/ux-turbo",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\UX\StimulusBundle\StimulusBundle;
+use Symfony\UX\Translator\UxTranslatorBundle;
 use Symfony\UX\Turbo\TurboBundle;
 use SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle;
 use SymfonyCasts\Bundle\VerifyEmail\SymfonyCastsVerifyEmailBundle;
@@ -40,4 +41,5 @@ return [
     StofDoctrineExtensionsBundle::class => ['all' => true],
     SymfonyCastsResetPasswordBundle::class => ['all' => true],
     SensiolabsTypeScriptBundle::class => ['all' => true],
+    UxTranslatorBundle::class => ['all' => true],
 ];

--- a/config/packages/ux_translator.yaml
+++ b/config/packages/ux_translator.yaml
@@ -1,0 +1,9 @@
+ux_translator:
+    # The directory where the JavaScript translations are dumped
+    dump_directory: '%kernel.project_dir%/var/translations'
+
+when@prod:
+    ux_translator:
+        # Control whether TypeScript types are dumped alongside translations.
+        # Disable this if you do not use TypeScript (e.g. in production when using AssetMapper), to speed up cache warmup.
+        # dump_typescript: false

--- a/config/reference.php
+++ b/config/reference.php
@@ -1503,6 +1503,15 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     swc_config_file?: scalar|Param|null, // Path to .swcrc configuration file to use // Default: "%kernel.project_dir%/.swcrc"
  *     swc_version?: scalar|Param|null, // The SWC version to use // Default: "v1.3.92"
  * }
+ * @psalm-type UxTranslatorConfig = array{
+ *     dump_directory?: scalar|Param|null, // The directory where translations and TypeScript types are dumped. // Default: "%kernel.project_dir%/var/translations"
+ *     dump_typescript?: bool|Param, // Control whether TypeScript types are dumped alongside translations. Disable this if you do not use TypeScript (e.g. in production when using AssetMapper). // Default: true
+ *     domains?: Param|string|array{ // List of domains to include/exclude from the generated translations. Prefix with a `!` to exclude a domain.
+ *         type?: scalar|Param|null,
+ *         elements?: list<scalar|Param|null>,
+ *     },
+ *     keys_patterns?: Param|string|list<scalar|Param|null>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1520,6 +1529,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     stof_doctrine_extensions?: StofDoctrineExtensionsConfig,
  *     symfonycasts_reset_password?: SymfonycastsResetPasswordConfig,
  *     sensiolabs_typescript?: SensiolabsTypescriptConfig,
+ *     ux_translator?: UxTranslatorConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1540,6 +1550,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         stof_doctrine_extensions?: StofDoctrineExtensionsConfig,
  *         symfonycasts_reset_password?: SymfonycastsResetPasswordConfig,
  *         sensiolabs_typescript?: SensiolabsTypescriptConfig,
+ *         ux_translator?: UxTranslatorConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -1559,6 +1570,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         stof_doctrine_extensions?: StofDoctrineExtensionsConfig,
  *         symfonycasts_reset_password?: SymfonycastsResetPasswordConfig,
  *         sensiolabs_typescript?: SensiolabsTypescriptConfig,
+ *         ux_translator?: UxTranslatorConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1579,6 +1591,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         stof_doctrine_extensions?: StofDoctrineExtensionsConfig,
  *         symfonycasts_reset_password?: SymfonycastsResetPasswordConfig,
  *         sensiolabs_typescript?: SensiolabsTypescriptConfig,
+ *         ux_translator?: UxTranslatorConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/deno.json
+++ b/deno.json
@@ -9,6 +9,7 @@
     "imports": {
         "@hotwired/stimulus": "npm:@hotwired/stimulus@^3.2.2",
         "@hotwired/turbo": "npm:@hotwired/turbo@^8.0.23",
+        "@symfony/ux-translator": "npm:@symfony/ux-translator@^3.2.0",
         "bootstrap": "npm:bootstrap@^5.3.8",
         "@sentry/browser": "npm:@sentry/browser@^10.63.0",
         "@std/assert": "jsr:@std/assert@^1.0.19"

--- a/deno.lock
+++ b/deno.lock
@@ -7,6 +7,7 @@
     "npm:@hotwired/stimulus@^3.2.2": "3.2.2",
     "npm:@hotwired/turbo@^8.0.23": "8.0.23",
     "npm:@sentry/browser@^10.63.0": "10.65.0",
+    "npm:@symfony/ux-translator@^3.2.0": "3.2.0_intl-messageformat@10.7.18",
     "npm:bootstrap@^5.3.8": "5.3.8_@popperjs+core@2.11.8"
   },
   "jsr": {
@@ -21,6 +22,42 @@
     }
   },
   "npm": {
+    "@formatjs/ecma402-abstract@2.3.6": {
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dependencies": [
+        "@formatjs/fast-memoize",
+        "@formatjs/intl-localematcher",
+        "decimal.js",
+        "tslib"
+      ]
+    },
+    "@formatjs/fast-memoize@2.2.7": {
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@formatjs/icu-messageformat-parser@2.11.4": {
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "dependencies": [
+        "@formatjs/ecma402-abstract",
+        "@formatjs/icu-skeleton-parser",
+        "tslib"
+      ]
+    },
+    "@formatjs/icu-skeleton-parser@1.8.16": {
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "dependencies": [
+        "@formatjs/ecma402-abstract",
+        "tslib"
+      ]
+    },
+    "@formatjs/intl-localematcher@0.6.2": {
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
     "@hotwired/stimulus@3.2.2": {
       "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
     },
@@ -77,11 +114,32 @@
         "@sentry/core"
       ]
     },
+    "@symfony/ux-translator@3.2.0_intl-messageformat@10.7.18": {
+      "integrity": "sha512-RdObWyvF6xZ77iwgYU8Rz9gNHD1WIdL+Yl/k53E8nlSOZzO7JX6doqBzBh+IyM+h1HJ7ImS6KnxwRZ3LfSJhIQ==",
+      "dependencies": [
+        "intl-messageformat"
+      ]
+    },
     "bootstrap@5.3.8_@popperjs+core@2.11.8": {
       "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "dependencies": [
         "@popperjs/core"
       ]
+    },
+    "decimal.js@10.6.0": {
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
+    },
+    "intl-messageformat@10.7.18": {
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "dependencies": [
+        "@formatjs/ecma402-abstract",
+        "@formatjs/fast-memoize",
+        "@formatjs/icu-messageformat-parser",
+        "tslib"
+      ]
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     }
   },
   "workspace": {
@@ -90,6 +148,7 @@
       "npm:@hotwired/stimulus@^3.2.2",
       "npm:@hotwired/turbo@^8.0.23",
       "npm:@sentry/browser@^10.63.0",
+      "npm:@symfony/ux-translator@^3.2.0",
       "npm:bootstrap@^5.3.8"
     ]
   }

--- a/importmap.php
+++ b/importmap.php
@@ -41,4 +41,10 @@ return [
     '@sentry/replay' => ['version' => '10.63.0'],
     '@sentry/replay-canvas' => ['version' => '10.63.0'],
     '@sentry/core' => ['version' => '10.63.0'],
+    'intl-messageformat' => ['version' => '10.7.18'],
+    'tslib' => ['version' => '2.8.1'],
+    '@formatjs/fast-memoize' => ['version' => '2.2.7'],
+    '@formatjs/icu-messageformat-parser' => ['version' => '2.11.4'],
+    '@formatjs/icu-skeleton-parser' => ['version' => '1.8.16'],
+    '@symfony/ux-translator' => ['path' => './vendor/symfony/ux-translator/assets/dist/translator_controller.js'],
 ];

--- a/symfony.lock
+++ b/symfony.lock
@@ -334,6 +334,20 @@
             "ref": "0df5844274d871b37fc3816c57a768ffc60a43a5"
         }
     },
+    "symfony/ux-translator": {
+        "version": "3.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.32",
+            "ref": "20e2abac415da4c3a9a6bafa059a6419beb74593"
+        },
+        "files": [
+            "assets/translator.js",
+            "config/packages/ux_translator.yaml",
+            "var/translations/index.js"
+        ]
+    },
     "symfony/ux-turbo": {
         "version": "2.26",
         "recipe": {

--- a/translations/messages+intl-icu.nl.yaml
+++ b/translations/messages+intl-icu.nl.yaml
@@ -1,3 +1,4 @@
+(required): (verplicht)
 'A candidate with this name already exists in this season': 'Er bestaat al een kandidaat met deze naam in dit seizoen'
 'A label with a similar name already exists': 'Er bestaat al een label met deze naam'
 'A new confirmation email has been sent. Please check your inbox.': 'Er is een nieuwe bevestigingsmail verstuurd. Check je inbox.'
@@ -13,6 +14,7 @@ Add: Toevoegen
 'Add Empty Quiz': 'Voeg een lege test toe'
 'Add Quiz': 'Test toevoegen'
 'Add a quiz to {name}': 'Voeg een test toe aan {name}'
+'Add a screenshot': 'Screenshot toevoegen'
 'Add answer': 'Antwoord toevoegen'
 'Add blank': 'Leeg toevoegen'
 'Add blank quiz': 'Lege quiz toevoegen'
@@ -57,6 +59,7 @@ Code: Code
 Colour: Kleur
 Completed: Voltooid
 Concept: Concept
+Confirm: Bevestigen
 'Confirm Answers': 'Bevestig antwoorden'
 'Confirm your email address to enable this feature.': 'Bevestig je e-mailadres om deze functie te kunnen gebruiken.'
 'Confirm your email address to enable this.': 'Bevestig je e-mailadres om dit te gebruiken.'
@@ -94,6 +97,7 @@ Delete: Verwijderen
 Delete...: Verwijderen...
 'Deleting this season hides it, its tests, and all candidate answers everywhere. There is no way to undo this yourself yet.': 'Als je dit seizoen verwijdert, wordt het overal verborgen, samen met de tests en antwoorden van kandidaten. Je kunt dit nog niet zelf ongedaan maken.'
 'Deleting your account also deletes every season you are the only owner of. This cannot be undone.': 'Als je je account verwijdert, worden ook alle seizoenen verwijderd waarvan jij de enige eigenaar bent. Dit kan niet ongedaan worden gemaakt.'
+Description: Beschrijving
 Done: Klaar
 'Download Template': 'Download sjabloon'
 'Download an archive of everything stored under your account: your profile, the seasons you own, their quizzes, results and candidates.': 'Download een archief met alles wat onder je account is opgeslagen: je profiel, de seizoenen die je bezit, met de bijbehorende testen, resultaten en kandidaten.'
@@ -229,11 +233,13 @@ Releases: Releases
 Remove: Verwijderen
 'Remove answer': 'Antwoord verwijderen'
 'Remove label': 'Label verwijderen'
+'Remove screenshot': 'Screenshot verwijderen'
 Rename: Hernoemen
 'Rename candidate': 'Kandidaat hernoemen'
 'Rename quiz': 'Test hernoemen'
 'Rename season': 'Seizoen hernoemen'
 'Repeat Password': 'Herhaal wachtwoord'
+'Report feedback': 'Feedback melden'
 'Resend confirmation email': 'Bevestigingsmail opnieuw versturen'
 'Reset password': 'Wachtwoord resetten'
 'Reset progress': 'Voortgang resetten'
@@ -255,6 +261,7 @@ Season: Seizoen
 'Season renamed': 'Seizoen hernoemd'
 Seasons: Seizoenen
 'Send a password reset email to {email}?': 'Wachtwoordherstel-e-mail sturen naar {email}?'
+'Send feedback': 'Feedback versturen'
 'Send password reset email': 'Stuur reset-e-mail'
 Settings: Instellingen
 'Show Numbers': 'Toon nummers'
@@ -266,6 +273,7 @@ Soon™: Soon™
 Status: Status
 Submit: Verstuur
 'Sync latest changes to this quiz': 'Laatste wijzigingen synchroniseren naar deze quiz'
+'Thank you for your report!': 'Bedankt voor je feedback!'
 'The candidate name must be between 1 and 16 characters': 'De naam van de kandidaat moet tussen de 1 en 16 tekens zijn'
 'The confirmation email could not be sent. Please try again later.': 'De bevestigingsmail kon niet worden verzonden. Probeer het later opnieuw.'
 'The confirmation email could not be sent. Please use the resend button to try again.': 'De bevestigingsmail kon niet worden verzonden. Gebruik de knop om het opnieuw te proberen.'
@@ -307,6 +315,7 @@ Unassign: Ontkoppelen
 Users: Gebruikers
 View: Bekijken
 'View on GitHub': 'Bekijk op GitHub'
+"What's the bug? What did you expect?": 'Wat ging er mis? Wat had je verwacht?'
 White: Wit
 'Wrong password, your account has not been deleted.': 'Verkeerd wachtwoord, je account is niet verwijderd.'
 Yellow: Geel
@@ -325,4 +334,5 @@ Yellow: Geel
 'Your password reset request': 'Verzoek tot wachtwoordreset'
 correct: goed
 'try again': 'probeer opnieuw'
+your.email@example.org: jouw.naam@voorbeeld.nl
 '{count, plural, one {Owner} other {Owners}}': '{count, plural, one {Eigenaar} other {Eigenaren}}'


### PR DESCRIPTION
## Summary
- Install `symfony/ux-translator` so the Sentry feedback widget's strings ("Report feedback", form labels, placeholders, etc.) go through the normal translation catalogue instead of being hardcoded in Dutch, and add the corresponding entries to `translations/messages+intl-icu.nl.yaml`.
- Widget now follows the app's manual light/dark toggle (`data-bs-theme`) via `feedbackIntegration.setTheme()` + a `MutationObserver`, instead of only reacting to OS `prefers-color-scheme`.

## Test plan
- [x] `just phpstan`, `php-cs-fixer` clean on touched PHP config
- [x] `deno check/fmt/lint` and `deno test` clean on touched TS
- [x] Manually verified in browser (dark + light): widget renders in Dutch, switches theme live when toggling the app theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dutch translations for feedback reporting, screenshot controls, form labels and confirmation messages.
  * Feedback widgets now automatically match the application’s light or dark theme.
  * Added support for translated feedback messages and labels throughout the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->